### PR TITLE
refactor SqlCommandParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-parser</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
             <version>2.10.1-9.0</version>
             <scope>provided</scope>

--- a/src/main/java/com/ververica/flink/table/gateway/SessionManager.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SessionManager.java
@@ -26,9 +26,6 @@ import com.ververica.flink.table.gateway.context.SessionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/ververica/flink/table/gateway/SessionManager.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SessionManager.java
@@ -26,6 +26,9 @@ import com.ververica.flink.table.gateway.context.SessionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
@@ -61,7 +61,7 @@ public final class SqlCommandParser {
 	/**
 	 * Parse the given statement and return corresponding SqlCommandCall.
 	 *
-	 * <p>only `show current_catalog`, `show current_database`, `show modules`, `set`, `reset`,
+	 * <p>only `show current catalog`, `show current database`, `show modules`, `set`, `reset`,
 	 * `describe`, `explain` are parsed through regex matching,
 	 * other commands are parsed through sql parser.
 	 *

--- a/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
@@ -18,6 +18,30 @@
 
 package com.ververica.flink.table.gateway;
 
+import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
+import org.apache.flink.sql.parser.ddl.SqlAlterTable;
+import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
+import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlCreateView;
+import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
+import org.apache.flink.sql.parser.ddl.SqlDropTable;
+import org.apache.flink.sql.parser.ddl.SqlDropView;
+import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
+import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
+import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
+import org.apache.flink.sql.parser.dql.SqlShowDatabases;
+import org.apache.flink.sql.parser.dql.SqlShowFunctions;
+import org.apache.flink.sql.parser.dql.SqlShowTables;
+import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
+
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.parser.SqlParser;
+
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,7 +51,6 @@ import java.util.regex.Pattern;
 
 /**
  * Simple parser for determining the type of command and its parameters.
- * TODO refactor using flink-sql-parser
  */
 public final class SqlCommandParser {
 
@@ -35,27 +58,135 @@ public final class SqlCommandParser {
 		// private
 	}
 
-	public static Optional<SqlCommandCall> parse(String stmt) {
+	/**
+	 * Parse the given statement and return corresponding SqlCommandCall.
+	 *
+	 * <p>only `show current_catalog`, `show current_database`, `show modules`, `set`, `reset`,
+	 * `describe`, `explain` are parsed through regex matching,
+	 * other commands are parsed through sql parser.
+	 *
+	 * <p>throw {@link SqlParseException} if the statement contains multiple sub-statements separated by semicolon
+	 * or there is a parse error.
+	 *
+	 * <p>NOTES: sql parser only parses the statement to get the corresponding SqlCommand,
+	 * do not check whether the statement is valid here.
+	 */
+	public static Optional<SqlCommandCall> parse(String stmt, boolean isBlinkPlanner) {
 		// normalize
-		stmt = stmt.trim();
+		String stmtForRegexMatch = stmt.trim();
 		// remove ';' at the end
-		if (stmt.endsWith(";")) {
-			stmt = stmt.substring(0, stmt.length() - 1).trim();
+		if (stmtForRegexMatch.endsWith(";")) {
+			stmtForRegexMatch = stmtForRegexMatch.substring(0, stmtForRegexMatch.length() - 1).trim();
 		}
 
-		// parse
+		// only parse gateway specific statements
 		for (SqlCommand cmd : SqlCommand.values()) {
-			final Matcher matcher = cmd.pattern.matcher(stmt);
-			if (matcher.matches()) {
-				final String[] groups = new String[matcher.groupCount()];
-				for (int i = 0; i < groups.length; i++) {
-					groups[i] = matcher.group(i + 1);
+			if (cmd.hasPattern()) {
+				final Matcher matcher = cmd.pattern.matcher(stmtForRegexMatch);
+				if (matcher.matches()) {
+					final String[] groups = new String[matcher.groupCount()];
+					for (int i = 0; i < groups.length; i++) {
+						groups[i] = matcher.group(i + 1);
+					}
+					return cmd.operandConverter.apply(groups)
+						.map((operands) -> new SqlCommandCall(cmd, operands));
 				}
-				return cmd.operandConverter.apply(groups)
-					.map((operands) -> new SqlCommandCall(cmd, operands));
 			}
 		}
-		return Optional.empty();
+
+		return parseStmt(stmt, isBlinkPlanner);
+	}
+
+	/**
+	 * Flink Parser only supports partial Operations, so we directly use Calcite Parser here.
+	 * Once Flink Parser supports all Operations, we should use Flink Parser instead of Calcite Parser.
+	 */
+	private static Optional<SqlCommandCall> parseStmt(String stmt, boolean isBlinkPlanner) {
+		SqlParser.Config config = createSqlParserConfig(isBlinkPlanner);
+		SqlParser sqlParser = SqlParser.create(stmt, config);
+		SqlNodeList sqlNodes;
+		try {
+			sqlNodes = sqlParser.parseStmtList();
+			// no need check the statement is valid here
+		} catch (org.apache.calcite.sql.parser.SqlParseException e) {
+			throw new SqlParseException("Failed to parse statement.", e);
+		}
+		if (sqlNodes.size() != 1) {
+			throw new SqlParseException("Only single statement is supported now");
+		}
+
+		final SqlCommand cmd;
+		SqlNode node = sqlNodes.get(0);
+		if (node.getKind().belongsTo(SqlKind.QUERY)) {
+			cmd = SqlCommand.SELECT;
+		} else if (node instanceof RichSqlInsert) {
+			cmd = ((RichSqlInsert) node).isOverwrite() ? SqlCommand.INSERT_OVERWRITE : SqlCommand.INSERT_INTO;
+		} else if (node instanceof SqlShowTables) {
+			cmd = SqlCommand.SHOW_TABLES;
+		} else if (node instanceof SqlCreateTable) {
+			cmd = SqlCommand.CREATE_TABLE;
+		} else if (node instanceof SqlDropTable) {
+			cmd = SqlCommand.DROP_TABLE;
+		} else if (node instanceof SqlAlterTable) {
+			cmd = SqlCommand.ALTER_TABLE;
+		} else if (node instanceof SqlCreateView) {
+			cmd = SqlCommand.CREATE_VIEW;
+		} else if (node instanceof SqlDropView) {
+			cmd = SqlCommand.DROP_VIEW;
+		} else if (node instanceof SqlShowDatabases) {
+			cmd = SqlCommand.SHOW_DATABASES;
+		} else if (node instanceof SqlCreateDatabase) {
+			cmd = SqlCommand.CREATE_DATABASE;
+		} else if (node instanceof SqlDropDatabase) {
+			cmd = SqlCommand.DROP_DATABASE;
+		} else if (node instanceof SqlAlterDatabase) {
+			cmd = SqlCommand.ALTER_DATABASE;
+		} else if (node instanceof SqlShowCatalogs) {
+			cmd = SqlCommand.SHOW_CATALOGS;
+		} else if (node instanceof SqlShowFunctions) {
+			cmd = SqlCommand.SHOW_FUNCTIONS;
+		} else if (node instanceof SqlUseCatalog) {
+			cmd = SqlCommand.USE_CATALOG;
+		} else if (node instanceof SqlUseDatabase) {
+			cmd = SqlCommand.USE;
+			// TODO remove `DESCRIBE` and supports `DESCRIBE TABLE`
+			// } else if (node instanceof SqlDescribeTable) {
+			//	cmd = SqlCommand.DESCRIBE;
+			// TODO remove `EXPLAIN` and supports `EXPLAIN PLAN`
+			// } else if (node instanceof SqlExplain) {
+			// 	md = SqlCommand.EXPLAIN;
+		} else {
+			cmd = null;
+		}
+		if (cmd == null) {
+			return Optional.empty();
+		} else {
+			// use the origin given statement to make sure
+			// users can find the correct line number when parsing failed
+			return Optional.of(new SqlCommandCall(cmd, stmt));
+		}
+	}
+
+	/**
+	 * A temporary solution. We can't get the default SqlParser config through table environment now.
+	 */
+	private static SqlParser.Config createSqlParserConfig(boolean isBlinkPlanner) {
+		if (isBlinkPlanner) {
+			return SqlParser
+				.configBuilder()
+				.setParserFactory(FlinkSqlParserImpl.FACTORY)
+				.setConformance(FlinkSqlConformance.DEFAULT)
+				.setLex(Lex.JAVA)
+				.setIdentifierMaxLength(256)
+				.build();
+		} else {
+			return SqlParser
+				.configBuilder()
+				.setParserFactory(FlinkSqlParserImpl.FACTORY)
+				.setConformance(FlinkSqlConformance.DEFAULT)
+				.setLex(Lex.JAVA)
+				.build();
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -64,7 +195,7 @@ public final class SqlCommandParser {
 		(operands) -> Optional.of(new String[0]);
 
 	private static final Function<String[], Optional<String[]>> SINGLE_OPERAND =
-		(operands) -> Optional.of(new String[]{operands[0]});
+		(operands) -> Optional.of(new String[] { operands[0] });
 
 	private static final int DEFAULT_PATTERN_FLAGS = Pattern.CASE_INSENSITIVE | Pattern.DOTALL;
 
@@ -72,94 +203,61 @@ public final class SqlCommandParser {
 	 * Supported SQL commands.
 	 */
 	public enum SqlCommand {
-		SHOW_CATALOGS(
-			"SHOW\\s+CATALOGS",
-			NO_OPERANDS),
+		SELECT,
+
+		INSERT_INTO,
+
+		INSERT_OVERWRITE,
+
+		CREATE_TABLE,
+
+		ALTER_TABLE,
+
+		DROP_TABLE,
+
+		CREATE_VIEW,
+
+		DROP_VIEW,
+
+		CREATE_DATABASE,
+
+		ALTER_DATABASE,
+
+		DROP_DATABASE,
+
+		USE_CATALOG,
+
+		USE,
+
+		SHOW_CATALOGS,
+
+		SHOW_DATABASES,
+
+		SHOW_TABLES,
+
+		SHOW_FUNCTIONS,
+
+		// keep this for compatibility
+		EXPLAIN(
+			"EXPLAIN\\s+(.*)",
+			SINGLE_OPERAND),
+
+		// keep this for compatibility
+		DESCRIBE(
+			"DESCRIBE\\s+(.*)",
+			SINGLE_OPERAND),
 
 		SHOW_CURRENT_CATALOG(
 			"SHOW\\s+CURRENT\\s+CATALOG",
-			NO_OPERANDS),
-
-		SHOW_DATABASES(
-			"SHOW\\s+DATABASES",
 			NO_OPERANDS),
 
 		SHOW_CURRENT_DATABASE(
 			"SHOW\\s+CURRENT\\s+DATABASE",
 			NO_OPERANDS),
 
-		SHOW_TABLES(
-			"SHOW\\s+TABLES",
-			NO_OPERANDS),
-
-		SHOW_FUNCTIONS(
-			"SHOW\\s+FUNCTIONS",
-			NO_OPERANDS),
-
 		SHOW_MODULES(
 			"SHOW\\s+MODULES",
 			NO_OPERANDS),
-
-		USE_CATALOG(
-			"USE\\s+CATALOG\\s+(.*)",
-			SINGLE_OPERAND),
-
-		USE(
-			"USE\\s+(?!CATALOG)(.*)",
-			SINGLE_OPERAND),
-
-		DESCRIBE(
-			"DESCRIBE\\s+(.*)",
-			SINGLE_OPERAND),
-
-		EXPLAIN(
-			"EXPLAIN\\s+(.*)",
-			SINGLE_OPERAND),
-
-		SELECT(
-			"(WITH.*SELECT.*|SELECT.*)",
-			SINGLE_OPERAND),
-
-		INSERT_INTO(
-			"(INSERT\\s+INTO.*)",
-			SINGLE_OPERAND),
-
-		INSERT_OVERWRITE(
-			"(INSERT\\s+OVERWRITE.*)",
-			SINGLE_OPERAND),
-
-		CREATE_TABLE("(CREATE\\s+TABLE\\s+.*)", SINGLE_OPERAND),
-
-		DROP_TABLE("(DROP\\s+TABLE\\s+.*)", SINGLE_OPERAND),
-
-		CREATE_VIEW(
-			"CREATE\\s+VIEW\\s+(\\S+)\\s+AS\\s+(.*)",
-			(operands) -> {
-				if (operands.length < 2) {
-					return Optional.empty();
-				}
-				return Optional.of(new String[]{operands[0], operands[1]});
-			}),
-
-		CREATE_DATABASE(
-				"(CREATE\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
-
-		DROP_DATABASE(
-				"(DROP\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
-
-		DROP_VIEW(
-			"DROP\\s+VIEW\\s+(.*)",
-			SINGLE_OPERAND),
-
-		ALTER_DATABASE(
-				"(ALTER\\s+DATABASE\\s+.*)",
-				SINGLE_OPERAND),
-
-		ALTER_TABLE(
-				"(ALTER\\s+TABLE\\s+.*)",
-				SINGLE_OPERAND),
 
 		SET(
 			"SET(\\s+(\\S+)\\s*=(.*))?", // whitespace is only ignored on the left side of '='
@@ -169,7 +267,7 @@ public final class SqlCommandParser {
 				} else if (operands[0] == null) {
 					return Optional.of(new String[0]);
 				}
-				return Optional.of(new String[]{operands[1], operands[2]});
+				return Optional.of(new String[] { operands[1], operands[2] });
 			}),
 
 		RESET(
@@ -184,13 +282,18 @@ public final class SqlCommandParser {
 			this.operandConverter = operandConverter;
 		}
 
+		SqlCommand() {
+			this.pattern = null;
+			this.operandConverter = null;
+		}
+
 		@Override
 		public String toString() {
 			return super.toString().replace('_', ' ');
 		}
 
-		public boolean hasOperands() {
-			return operandConverter != NO_OPERANDS;
+		boolean hasPattern() {
+			return pattern != null;
 		}
 	}
 
@@ -206,8 +309,8 @@ public final class SqlCommandParser {
 			this.operands = operands;
 		}
 
-		public SqlCommandCall(SqlCommand command) {
-			this(command, new String[0]);
+		public SqlCommandCall(SqlCommand command, String operand) {
+			this(command, new String[] { operand });
 		}
 
 		@Override

--- a/src/main/java/com/ververica/flink/table/gateway/SqlParseException.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlParseException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.table.gateway;
+
+/**
+ * Exception thrown during parsing SQL statement.
+ */
+public class SqlParseException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public SqlParseException(String message) {
+		super(message);
+	}
+
+	public SqlParseException(String message, Throwable e) {
+		super(message, e);
+	}
+}

--- a/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.table.gateway;
+
+import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand;
+import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link SqlCommandParser}.
+ */
+public class SqlCommandParserTest {
+
+	@Test
+	public void testSelect() {
+		String query1 = "select * from MyTable";
+		checkCommand(query1, SqlCommand.SELECT);
+
+		String query2 = "-- single-line comment \n select * from MyTable";
+		checkCommand(query2, SqlCommand.SELECT);
+
+		String query3 = "/* multi-line comments \n more comments */ \n select * from MyTable";
+		checkCommand(query3, SqlCommand.SELECT);
+
+		String query4 = "select * from MyTable \n -- single-line comment";
+		checkCommand(query4, SqlCommand.SELECT);
+
+		String query5 = " \n select abc from MyTable \n";
+		checkCommand(query5, SqlCommand.SELECT);
+	}
+
+	@Test
+	public void testSelectWith() {
+		String query1 = "with t as " +
+			"(select * from MyTable where a > 10) " +
+			"select * from t where c is not null;";
+		checkCommand(query1, SqlCommand.SELECT);
+
+		String query2 = "/* multi-line comments */ \n" +
+			" -- single-line comments \n" +
+			" with t as " +
+			"(select * from MyTable where a > 10) " +
+			"select * from t where c is not null \n --with statement; ";
+		checkCommand(query2, SqlCommand.SELECT);
+	}
+
+	@Test(expected = SqlParseException.class)
+	public void testInvalidSelect() {
+		String query = "select * from MyTable where";
+		checkCommand(query, SqlCommand.SELECT);
+	}
+
+	@Test
+	public void testInvalidSelectToCheckLineNumber() {
+		String query = "\n\nselect * from MyTable \nwhere\n";
+		try {
+			SqlCommandParser.parse(query, true);
+			fail();
+		} catch (SqlParseException e) {
+			assertTrue(e.getCause().getMessage().contains("Encountered \"<EOF>\" at line 4, column 6."));
+		}
+	}
+
+	@Test
+	public void testInsert() {
+		String query1 = "insert into MySink select * from MyTable where a > 10";
+		checkCommand(query1, SqlCommand.INSERT_INTO);
+
+		String query2 = "\n -- single-line comment \n insert into MySink select * from MyTable where a > 10 " +
+			"/* multi-line comments \n more comments */ \n";
+		checkCommand(query2, SqlCommand.INSERT_INTO);
+	}
+
+	@Test
+	public void testInsertOverwrite() {
+		String query1 = "insert overwrite MySink select * from MyTable where a > 10";
+		checkCommand(query1, SqlCommand.INSERT_OVERWRITE);
+
+		String query2 = "\n -- single-line comment \n insert overwrite MySink select * from MyTable where a > 10 " +
+			"/* multi-line comments \n more comments */ \n";
+		checkCommand(query2, SqlCommand.INSERT_OVERWRITE);
+	}
+
+	@Test
+	public void testCreateTable() {
+		String query1 = "create table MyTable (a int);";
+		checkCommand(query1, SqlCommand.CREATE_TABLE);
+
+		String query2 = " \n -- single-line comment \n create \n table \n MyTable (a int);";
+		checkCommand(query2, SqlCommand.CREATE_TABLE);
+	}
+
+	@Test
+	public void testDropTable() {
+		String query1 = "drop table MyTable;";
+		checkCommand(query1, SqlCommand.DROP_TABLE);
+
+		String query2 = " \n -- single-line comment \n drop \n table \n MyTable;";
+		checkCommand(query2, SqlCommand.DROP_TABLE);
+	}
+
+	@Test
+	public void testAlterTable() {
+		String query1 = "alter table MyTable rename to MyTable2;";
+		checkCommand(query1, SqlCommand.ALTER_TABLE);
+
+		String query2 = " \n -- single-line comment \n alter \n table MyTable rename to MyTable2" +
+			"\n  /* multi-line comments */";
+		checkCommand(query2, SqlCommand.ALTER_TABLE);
+	}
+
+	@Test
+	public void testCreateView() {
+		String query1 = "create view MyView as select * from MyTable where a > 10;";
+		checkCommand(query1, SqlCommand.CREATE_VIEW);
+
+		String query2 = " \n -- single-line comment \n create \n -- single-line comment \n view MyView as" +
+			" select * from MyTable where a > 10" +
+			"\n  /* multi-line comments */";
+		checkCommand(query2, SqlCommand.CREATE_VIEW);
+	}
+
+
+	@Test
+	public void testDropView() {
+		String query1 = "drop view MyView;";
+		checkCommand(query1, SqlCommand.DROP_VIEW);
+
+		String query2 = " \n -- single-line comment \n drop \n view \n MyView;";
+		checkCommand(query2, SqlCommand.DROP_VIEW);
+	}
+
+	@Test
+	public void testCreateDatabase() {
+		String query1 = "create database MyDb;";
+		checkCommand(query1, SqlCommand.CREATE_DATABASE);
+
+		String query2 = " \n -- single-line comment \n create \n database \n MyDb;";
+		checkCommand(query2, SqlCommand.CREATE_DATABASE);
+	}
+
+	@Test
+	public void testDropDatabase() {
+		String query1 = "drop database MyDb;";
+		checkCommand(query1, SqlCommand.DROP_DATABASE);
+
+		String query2 = " \n -- single-line comment \n drop \n database \n MyDb;";
+		checkCommand(query2, SqlCommand.DROP_DATABASE);
+	}
+
+	@Test
+	public void testAlterDatabase() {
+		String query1 = "alter database MyDb set ('k1' = 'a');";
+		checkCommand(query1, SqlCommand.ALTER_DATABASE);
+
+		String query2 = " \n -- single-line comment \n alter \n database MyDb set ('k1' = 'a')" +
+			"\n  /* multi-line comments */";
+		checkCommand(query2, SqlCommand.ALTER_DATABASE);
+	}
+
+	@Test
+	public void testUseCatalog() {
+		String query1 = "use catalog MyCat";
+		checkCommand(query1, SqlCommand.USE_CATALOG);
+
+		String query2 = "\n -- comments \n use \n -- comments \n catalog MyCat ;  -- comments";
+		checkCommand(query2, SqlCommand.USE_CATALOG);
+	}
+
+	@Test
+	public void testUseDatabase() {
+		String query1 = "use MyCat.MyDb";
+		checkCommand(query1, SqlCommand.USE);
+
+		String query2 = "\n -- comments \n  use \n -- comments \n MyCat.MyDb ; -- comments";
+		checkCommand(query2, SqlCommand.USE);
+	}
+
+	@Test
+	public void testShowCatalogs() {
+		String query1 = "show catalogs";
+		checkCommand(query1, SqlCommand.SHOW_CATALOGS);
+
+		String query2 = "\n -- comments \n  show \n -- comments \n catalogs; -- comments";
+		checkCommand(query2, SqlCommand.SHOW_CATALOGS);
+	}
+
+	@Test
+	public void testShowDatabases() {
+		String query1 = "show databases";
+		checkCommand(query1, SqlCommand.SHOW_DATABASES);
+
+		String query2 = "\n -- comments \n  show \n -- comments \n databases; -- comments";
+		checkCommand(query2, SqlCommand.SHOW_DATABASES);
+	}
+
+	@Test
+	public void testShowTables() {
+		String query1 = "show tables";
+		checkCommand(query1, SqlCommand.SHOW_TABLES);
+
+		String query2 = "\n -- comments \n show \n -- comments \n tables; -- comments";
+		checkCommand(query2, SqlCommand.SHOW_TABLES);
+	}
+
+	@Test
+	public void testShowFunctions() {
+		String query1 = "show functions";
+		checkCommand(query1, SqlCommand.SHOW_FUNCTIONS);
+
+		String query2 = "\n -- comments \n show \n -- comments \n functions; -- comments";
+		checkCommand(query2, SqlCommand.SHOW_FUNCTIONS);
+	}
+
+	@Test
+	public void testDescribe() {
+		String query1 = "describe MyTable";
+		checkCommand(query1, SqlCommand.DESCRIBE, "MyTable");
+	}
+
+	@Ignore
+	@Test
+	public void testDescribeTable() {
+		String query2 = "describe table MyTable";
+		checkCommand(query2, SqlCommand.DESCRIBE, "MyTable");
+
+		String query3 = "\n -- comments \n describe \n -- comments \n table  MyTable; -- comments";
+		checkCommand(query3, SqlCommand.DESCRIBE, "MyTable");
+	}
+
+	@Test
+	public void testExplain() {
+		String query1 = "explain select * from MyTable";
+		checkCommand(query1, SqlCommand.EXPLAIN, "select * from MyTable");
+	}
+
+	@Ignore
+	@Test
+	public void testExplainPlan() {
+		String query1 = "explain plan for select * from MyTable";
+		checkCommand(query1, SqlCommand.EXPLAIN);
+	}
+
+	private void checkCommand(String stmt, SqlCommand expectedCmd) {
+		Optional<SqlCommandCall> cmd2 = SqlCommandParser.parse(stmt, true);
+		assertTrue(cmd2.isPresent());
+		assertEquals(expectedCmd, cmd2.get().command);
+		assertEquals(1, cmd2.get().operands.length);
+		assertEquals(stmt, cmd2.get().operands[0]);
+	}
+
+	private void checkCommand(String stmt, SqlCommand expectedCmd, String expectedOperand) {
+		Optional<SqlCommandCall> cmd2 = SqlCommandParser.parse(stmt, true);
+		assertTrue(cmd2.isPresent());
+		assertEquals(expectedCmd, cmd2.get().command);
+		assertEquals(1, cmd2.get().operands.length);
+		assertEquals(expectedOperand, cmd2.get().operands[0]);
+	}
+}

--- a/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -38,19 +39,19 @@ public class SqlCommandParserTest {
 	@Test
 	public void testSelect() {
 		String query1 = "select * from MyTable";
-		checkCommand(query1, SqlCommand.SELECT);
+		checkCommand(query1, SqlCommand.SELECT, query1);
 
 		String query2 = "-- single-line comment \n select * from MyTable";
-		checkCommand(query2, SqlCommand.SELECT);
+		checkCommand(query2, SqlCommand.SELECT, query2);
 
 		String query3 = "/* multi-line comments \n more comments */ \n select * from MyTable";
-		checkCommand(query3, SqlCommand.SELECT);
+		checkCommand(query3, SqlCommand.SELECT, query3);
 
 		String query4 = "select * from MyTable \n -- single-line comment";
-		checkCommand(query4, SqlCommand.SELECT);
+		checkCommand(query4, SqlCommand.SELECT, query4);
 
 		String query5 = " \n select abc from MyTable \n";
-		checkCommand(query5, SqlCommand.SELECT);
+		checkCommand(query5, SqlCommand.SELECT, query5);
 	}
 
 	@Test
@@ -58,20 +59,20 @@ public class SqlCommandParserTest {
 		String query1 = "with t as " +
 			"(select * from MyTable where a > 10) " +
 			"select * from t where c is not null;";
-		checkCommand(query1, SqlCommand.SELECT);
+		checkCommand(query1, SqlCommand.SELECT, query1);
 
 		String query2 = "/* multi-line comments */ \n" +
 			" -- single-line comments \n" +
 			" with t as " +
 			"(select * from MyTable where a > 10) " +
 			"select * from t where c is not null \n --with statement; ";
-		checkCommand(query2, SqlCommand.SELECT);
+		checkCommand(query2, SqlCommand.SELECT, query2);
 	}
 
 	@Test(expected = SqlParseException.class)
 	public void testInvalidSelect() {
 		String query = "select * from MyTable where";
-		checkCommand(query, SqlCommand.SELECT);
+		checkCommand(query, SqlCommand.SELECT, query);
 	}
 
 	@Test
@@ -88,116 +89,115 @@ public class SqlCommandParserTest {
 	@Test
 	public void testInsert() {
 		String query1 = "insert into MySink select * from MyTable where a > 10";
-		checkCommand(query1, SqlCommand.INSERT_INTO);
+		checkCommand(query1, SqlCommand.INSERT_INTO, query1);
 
 		String query2 = "\n -- single-line comment \n insert into MySink select * from MyTable where a > 10 " +
 			"/* multi-line comments \n more comments */ \n";
-		checkCommand(query2, SqlCommand.INSERT_INTO);
+		checkCommand(query2, SqlCommand.INSERT_INTO, query2);
 	}
 
 	@Test
 	public void testInsertOverwrite() {
 		String query1 = "insert overwrite MySink select * from MyTable where a > 10";
-		checkCommand(query1, SqlCommand.INSERT_OVERWRITE);
+		checkCommand(query1, SqlCommand.INSERT_OVERWRITE, query1);
 
 		String query2 = "\n -- single-line comment \n insert overwrite MySink select * from MyTable where a > 10 " +
 			"/* multi-line comments \n more comments */ \n";
-		checkCommand(query2, SqlCommand.INSERT_OVERWRITE);
+		checkCommand(query2, SqlCommand.INSERT_OVERWRITE, query2);
 	}
 
 	@Test
 	public void testCreateTable() {
 		String query1 = "create table MyTable (a int);";
-		checkCommand(query1, SqlCommand.CREATE_TABLE);
+		checkCommand(query1, SqlCommand.CREATE_TABLE, query1);
 
 		String query2 = " \n -- single-line comment \n create \n table \n MyTable (a int);";
-		checkCommand(query2, SqlCommand.CREATE_TABLE);
+		checkCommand(query2, SqlCommand.CREATE_TABLE, query2);
 	}
 
 	@Test
 	public void testDropTable() {
 		String query1 = "drop table MyTable;";
-		checkCommand(query1, SqlCommand.DROP_TABLE);
+		checkCommand(query1, SqlCommand.DROP_TABLE, query1);
 
 		String query2 = " \n -- single-line comment \n drop \n table \n MyTable;";
-		checkCommand(query2, SqlCommand.DROP_TABLE);
+		checkCommand(query2, SqlCommand.DROP_TABLE, query2);
 	}
 
 	@Test
 	public void testAlterTable() {
 		String query1 = "alter table MyTable rename to MyTable2;";
-		checkCommand(query1, SqlCommand.ALTER_TABLE);
+		checkCommand(query1, SqlCommand.ALTER_TABLE, query1);
 
 		String query2 = " \n -- single-line comment \n alter \n table MyTable rename to MyTable2" +
 			"\n  /* multi-line comments */";
-		checkCommand(query2, SqlCommand.ALTER_TABLE);
+		checkCommand(query2, SqlCommand.ALTER_TABLE, query2);
 	}
 
 	@Test
 	public void testCreateView() {
 		String query1 = "create view MyView as select * from MyTable where a > 10;";
-		checkCommand(query1, SqlCommand.CREATE_VIEW);
+		checkCommand(query1, SqlCommand.CREATE_VIEW, query1);
 
 		String query2 = " \n -- single-line comment \n create \n -- single-line comment \n view MyView as" +
 			" select * from MyTable where a > 10" +
 			"\n  /* multi-line comments */";
-		checkCommand(query2, SqlCommand.CREATE_VIEW);
+		checkCommand(query2, SqlCommand.CREATE_VIEW, query2);
 	}
-
 
 	@Test
 	public void testDropView() {
 		String query1 = "drop view MyView;";
-		checkCommand(query1, SqlCommand.DROP_VIEW);
+		checkCommand(query1, SqlCommand.DROP_VIEW, query1);
 
 		String query2 = " \n -- single-line comment \n drop \n view \n MyView;";
-		checkCommand(query2, SqlCommand.DROP_VIEW);
+		checkCommand(query2, SqlCommand.DROP_VIEW, query2);
 	}
 
 	@Test
 	public void testCreateDatabase() {
 		String query1 = "create database MyDb;";
-		checkCommand(query1, SqlCommand.CREATE_DATABASE);
+		checkCommand(query1, SqlCommand.CREATE_DATABASE, query1);
 
 		String query2 = " \n -- single-line comment \n create \n database \n MyDb;";
-		checkCommand(query2, SqlCommand.CREATE_DATABASE);
+		checkCommand(query2, SqlCommand.CREATE_DATABASE, query2);
 	}
 
 	@Test
 	public void testDropDatabase() {
 		String query1 = "drop database MyDb;";
-		checkCommand(query1, SqlCommand.DROP_DATABASE);
+		checkCommand(query1, SqlCommand.DROP_DATABASE, query1);
 
 		String query2 = " \n -- single-line comment \n drop \n database \n MyDb;";
-		checkCommand(query2, SqlCommand.DROP_DATABASE);
+		checkCommand(query2, SqlCommand.DROP_DATABASE, query2);
 	}
 
 	@Test
 	public void testAlterDatabase() {
 		String query1 = "alter database MyDb set ('k1' = 'a');";
-		checkCommand(query1, SqlCommand.ALTER_DATABASE);
+		checkCommand(query1, SqlCommand.ALTER_DATABASE, query1);
 
 		String query2 = " \n -- single-line comment \n alter \n database MyDb set ('k1' = 'a')" +
 			"\n  /* multi-line comments */";
-		checkCommand(query2, SqlCommand.ALTER_DATABASE);
+		checkCommand(query2, SqlCommand.ALTER_DATABASE, query2);
 	}
 
 	@Test
 	public void testUseCatalog() {
 		String query1 = "use catalog MyCat";
-		checkCommand(query1, SqlCommand.USE_CATALOG);
+		checkCommand(query1, SqlCommand.USE_CATALOG, "MyCat");
 
 		String query2 = "\n -- comments \n use \n -- comments \n catalog MyCat ;  -- comments";
-		checkCommand(query2, SqlCommand.USE_CATALOG);
+		checkCommand(query2, SqlCommand.USE_CATALOG, "MyCat");
 	}
 
 	@Test
 	public void testUseDatabase() {
 		String query1 = "use MyCat.MyDb";
-		checkCommand(query1, SqlCommand.USE);
+		checkCommand(query1, SqlCommand.USE, "MyCat.MyDb");
 
 		String query2 = "\n -- comments \n  use \n -- comments \n MyCat.MyDb ; -- comments";
-		checkCommand(query2, SqlCommand.USE);
+		checkCommand(query2, SqlCommand.USE, "MyCat.MyDb");
 	}
 
 	@Test
@@ -265,19 +265,19 @@ public class SqlCommandParserTest {
 		checkCommand(query1, SqlCommand.EXPLAIN);
 	}
 
-	private void checkCommand(String stmt, SqlCommand expectedCmd) {
-		Optional<SqlCommandCall> cmd2 = SqlCommandParser.parse(stmt, true);
-		assertTrue(cmd2.isPresent());
-		assertEquals(expectedCmd, cmd2.get().command);
-		assertEquals(1, cmd2.get().operands.length);
-		assertEquals(stmt, cmd2.get().operands[0]);
+	@Test
+	public void testSet() {
+		String query1 = "set execution.parallelism=10";
+		checkCommand(query1, SqlCommand.SET, "execution.parallelism", "10");
+
+		String query2 = "set";
+		checkCommand(query2, SqlCommand.SET);
 	}
 
-	private void checkCommand(String stmt, SqlCommand expectedCmd, String expectedOperand) {
+	private void checkCommand(String stmt, SqlCommand expectedCmd, String... expectedOperand) {
 		Optional<SqlCommandCall> cmd2 = SqlCommandParser.parse(stmt, true);
 		assertTrue(cmd2.isPresent());
 		assertEquals(expectedCmd, cmd2.get().command);
-		assertEquals(1, cmd2.get().operands.length);
-		assertEquals(expectedOperand, cmd2.get().operands[0]);
+		assertArrayEquals(expectedOperand, cmd2.get().operands);
 	}
 }


### PR DESCRIPTION
only `show current_catalog`, `show current_database`, `show modules`, `set`, `reset`, `describe`, `explain` are parsed through regex matching, other commands are parsed through sql parser.