### PR TITLE
Trim the key/value when calling set command

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
@@ -75,7 +75,7 @@ public class SetOperation implements NonJobOperation {
 		} else {
 			// TODO avoid to build a new Environment for some cases
 			// set a property
-			Environment newEnv = Environment.enrich(env, ImmutableMap.of(key, value), ImmutableMap.of());
+			Environment newEnv = Environment.enrich(env, ImmutableMap.of(key.trim(), value.trim()), ImmutableMap.of());
 			// Renew the ExecutionContext by new environment.
 			// Book keep all the session states of current ExecutionContext then
 			// re-register them into the new one.

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
@@ -74,6 +74,28 @@ public class SetOperationTest extends OperationTestBase {
 	}
 
 	@Test
+	public void testSetPropertiesWithWhitespace() {
+		SetOperation setOperation = new SetOperation(context, "execution.parallelism", " 10");
+		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation.execute());
+
+		SetOperation showSetOperation = new SetOperation(context);
+		ResultSet resultSet = showSetOperation.execute();
+		ResultSet expected = new ResultSet(
+			Arrays.asList(
+				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
+			Arrays.asList(
+				Row.of("execution.max-parallelism", "16"),
+				Row.of("execution.planner", "old"),
+				Row.of("execution.parallelism", "10"),
+				Row.of("execution.type", "batch"),
+				Row.of("deployment.response-timeout", "5000"),
+				Row.of("table.optimizer.join-reorder-enabled", "false"))
+		);
+		assertEquals(expected, resultSet);
+	}
+
+	@Test
 	public void testShowProperties() {
 		SetOperation operation = new SetOperation(context);
 		ResultSet resultSet = operation.execute();


### PR DESCRIPTION
Failed to execute `set execution.parallelism = 10` because error occurs `Property 'parallelism' must be an integer value but was:  10`. The reason the `' 10'` can't converted to integer. 