### PR TITLE
Fix ClusterDescriptor fetching under HA mode and clean up ExecutionContext

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapter.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapter.java
@@ -119,7 +119,8 @@ public abstract class ClusterDescriptorAdapter<ClusterID> {
 			throw new IllegalStateException("Cluster information don't exist.");
 		}
 		// stop Flink job
-		try (final ClusterDescriptor<ClusterID> clusterDescriptor = executionContext.createClusterDescriptor()) {
+		try (final ClusterDescriptor<ClusterID> clusterDescriptor =
+				executionContext.createClusterDescriptor(configuration)) {
 			try (ClusterClient<ClusterID> clusterClient =
 						clusterDescriptor.retrieve(this.clusterID).getClusterClient()) {
 				// retrieve existing cluster


### PR DESCRIPTION
This PR fixes the fetching of `ClusterDescriptor` under HA mode by reusing the configuration when submitting the job. The configuration has to be reused as it contains critical information like `high-availability.cluster-id` when the job is submitted.

This PR also cleans up `ExecutionContext` by removing unused methods and fields.