### PR TITLE
update execution result based on FLIP-84

### DIFF
--- a/e2e-tests/test-commons.sh
+++ b/e2e-tests/test-commons.sh
@@ -232,5 +232,5 @@ EOF`
 
 function run_ddl() {
     res=`run_non_job_statement "$1" "$2" "$3"`
-    assert_equals 0 "$res"
+    assert_equals "OK" "$res"
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
@@ -200,11 +200,14 @@ public abstract class AbstractJobOperation implements JobOperation {
 			throw new SqlGatewayException(msg);
 		}
 
-		return Optional.of(new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			getColumnInfos(),
-			getLinkedListElementsFromBegin(bufferedResults, previousResultSetSize),
-			getLinkedListElementsFromBegin(bufferedChangeFlags, previousResultSetSize)));
+		return Optional.of(
+			ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(getColumnInfos())
+				.data(getLinkedListElementsFromBegin(bufferedResults, previousResultSetSize))
+				.changeFlags(getLinkedListElementsFromBegin(bufferedChangeFlags, previousResultSetSize))
+				.build()
+		);
 	}
 
 	protected abstract Optional<Tuple2<List<Row>, List<Boolean>>> fetchNewJobResults();

--- a/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
@@ -22,6 +22,7 @@ import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapter;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.api.common.JobID;
@@ -200,6 +201,7 @@ public abstract class AbstractJobOperation implements JobOperation {
 		}
 
 		return Optional.of(new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			getColumnInfos(),
 			getLinkedListElementsFromBegin(bufferedResults, previousResultSetSize),
 			getLinkedListElementsFromBegin(bufferedChangeFlags, previousResultSetSize)));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/CreateViewOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/CreateViewOperation.java
@@ -55,6 +55,6 @@ public class CreateViewOperation implements NonJobOperation {
 		tableEnv.createTemporaryView(viewName, tableEnv.sqlQuery(query));
 		// Also attach the view to ExecutionContext#environment.
 		env.getTables().put(viewName, ViewEntry.create(viewName, query));
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DDLOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DDLOperation.java
@@ -60,7 +60,7 @@ public class DDLOperation implements NonJobOperation {
 			throw new SqlExecutionException(getExceptionMsg(), t);
 		}
 
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 
 	private String getExceptionMsg() {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeOperation.java
@@ -23,6 +23,7 @@ import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.rest.result.TableSchemaUtil;
 
@@ -58,6 +59,7 @@ public class DescribeOperation implements NonJobOperation {
 			data.add(Row.of(schemaJson));
 
 			return new ResultSet(
+				ResultKind.SUCCESS_WITH_CONTENT,
 				Collections.singletonList(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, length))),
 				data);
 		} catch (Throwable t) {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeOperation.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -58,10 +57,11 @@ public class DescribeOperation implements NonJobOperation {
 			List<Row> data = new ArrayList<>();
 			data.add(Row.of(schemaJson));
 
-			return new ResultSet(
-				ResultKind.SUCCESS_WITH_CONTENT,
-				Collections.singletonList(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, length))),
-				data);
+			return ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, length)))
+				.data(data)
+				.build();
 		} catch (Throwable t) {
 			// catch everything such that the query does not crash the executor
 			throw new SqlExecutionException("No table with this name could be found.", t);

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DropViewOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DropViewOperation.java
@@ -68,6 +68,6 @@ public class DropViewOperation implements NonJobOperation {
 			context.setExecutionContext(newExecutionContext);
 		}
 
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
@@ -23,6 +23,7 @@ import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.table.api.Table;
@@ -52,6 +53,7 @@ public class ExplainOperation implements NonJobOperation {
 			final Table table = createTable(context, tableEnv, statement);
 			String explanation = context.wrapClassLoader(() -> tableEnv.explain(table));
 			return new ResultSet(
+				ResultKind.SUCCESS_WITH_CONTENT,
 				Collections.singletonList(
 					ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, explanation.length()))),
 				Collections.singletonList(Row.of(explanation)));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
@@ -31,8 +31,6 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
-import java.util.Collections;
-
 /**
  * Operation for EXPLAIN command.
  */
@@ -52,11 +50,11 @@ public class ExplainOperation implements NonJobOperation {
 		try {
 			final Table table = createTable(context, tableEnv, statement);
 			String explanation = context.wrapClassLoader(() -> tableEnv.explain(table));
-			return new ResultSet(
-				ResultKind.SUCCESS_WITH_CONTENT,
-				Collections.singletonList(
-					ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, explanation.length()))),
-				Collections.singletonList(Row.of(explanation)));
+			return ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, explanation.length())))
+				.data(Row.of(explanation))
+				.build();
 		} catch (Throwable t) {
 			// catch everything such that the query does not crash the executor
 			throw new SqlExecutionException("Invalid SQL statement.", t);

--- a/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
@@ -78,11 +78,11 @@ public class InsertOperation extends AbstractJobOperation {
 	public ResultSet execute() {
 		jobId = executeUpdateInternal(context.getExecutionContext());
 		String strJobId = jobId.toString();
-		return new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(
-				ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, strJobId.length()))),
-			Collections.singletonList(Row.of(strJobId)));
+		return ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, strJobId.length())))
+			.data(Row.of(strJobId))
+			.build();
 	}
 
 	@Override

--- a/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
@@ -25,6 +25,7 @@ import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapterFactory;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.api.common.JobID;
@@ -78,6 +79,7 @@ public class InsertOperation extends AbstractJobOperation {
 		jobId = executeUpdateInternal(context.getExecutionContext());
 		String strJobId = jobId.toString();
 		return new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(
 				ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, strJobId.length()))),
 			Collections.singletonList(Row.of(strJobId)));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
@@ -20,6 +20,7 @@ package com.ververica.flink.table.gateway.operation;
 
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.table.types.logical.BigIntType;
@@ -36,11 +37,13 @@ import java.util.List;
 public class OperationUtil {
 
 	public static final ResultSet AFFECTED_ROW_COUNT0 = new ResultSet(
+		ResultKind.SUCCESS,
 		Collections.singletonList(ColumnInfo.create(ConstantNames.AFFECTED_ROW_COUNT, new BigIntType(false))),
 		Collections.singletonList(Row.of(0L)));
 
 	public static ResultSet singleStringToResultSet(String str, String columnName) {
 		return new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList((ColumnInfo.create(columnName, new VarCharType(false, str.length())))),
 			Collections.singletonList(Row.of(str)));
 	}
@@ -56,6 +59,6 @@ public class OperationUtil {
 
 		List<ColumnInfo> columnInfos = Collections.singletonList(
 			ColumnInfo.create(columnName, new VarCharType(false, maxLength)));
-		return new ResultSet(columnInfos, data);
+		return new ResultSet(ResultKind.SUCCESS_WITH_CONTENT, columnInfos, data);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
@@ -23,7 +23,6 @@ import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
-import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
@@ -36,10 +35,10 @@ import java.util.List;
  */
 public class OperationUtil {
 
-	public static final ResultSet AFFECTED_ROW_COUNT0 = new ResultSet(
+	public static final ResultSet OK = new ResultSet(
 		ResultKind.SUCCESS,
-		Collections.singletonList(ColumnInfo.create(ConstantNames.AFFECTED_ROW_COUNT, new BigIntType(false))),
-		Collections.singletonList(Row.of(0L)));
+		Collections.singletonList(ColumnInfo.create(ConstantNames.RESULT, new VarCharType(2))),
+		Collections.singletonList(Row.of("OK")));
 
 	public static ResultSet singleStringToResultSet(String str, String columnName) {
 		return new ResultSet(

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -35,16 +34,18 @@ import java.util.List;
  */
 public class OperationUtil {
 
-	public static final ResultSet OK = new ResultSet(
-		ResultKind.SUCCESS,
-		Collections.singletonList(ColumnInfo.create(ConstantNames.RESULT, new VarCharType(2))),
-		Collections.singletonList(Row.of("OK")));
+	public static final ResultSet OK = ResultSet.builder()
+		.resultKind(ResultKind.SUCCESS)
+		.columns(ColumnInfo.create(ConstantNames.RESULT, new VarCharType(2)))
+		.data(Row.of("OK"))
+		.build();
 
 	public static ResultSet singleStringToResultSet(String str, String columnName) {
-		return new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList((ColumnInfo.create(columnName, new VarCharType(false, str.length())))),
-			Collections.singletonList(Row.of(str)));
+		return ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(columnName, new VarCharType(false, str.length())))
+			.data(Row.of(str))
+			.build();
 	}
 
 	public static ResultSet stringListToResultSet(List<String> strings, String columnName) {
@@ -56,8 +57,10 @@ public class OperationUtil {
 			data.add(Row.of(str));
 		}
 
-		List<ColumnInfo> columnInfos = Collections.singletonList(
-			ColumnInfo.create(columnName, new VarCharType(false, maxLength)));
-		return new ResultSet(ResultKind.SUCCESS_WITH_CONTENT, columnInfos, data);
+		return ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(columnName, new VarCharType(false, maxLength)))
+			.data(data)
+			.build();
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationUtil.java
@@ -37,7 +37,7 @@ public class OperationUtil {
 	public static final ResultSet OK = ResultSet.builder()
 		.resultKind(ResultKind.SUCCESS)
 		.columns(ColumnInfo.create(ConstantNames.RESULT, new VarCharType(2)))
-		.data(Row.of("OK"))
+		.data(Row.of(ConstantNames.OK))
 		.build();
 
 	public static ResultSet singleStringToResultSet(String str, String columnName) {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ResetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ResetOperation.java
@@ -44,6 +44,6 @@ public class ResetOperation implements NonJobOperation {
 			.build();
 		context.setExecutionContext(newExecutionContext);
 
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
@@ -93,11 +93,11 @@ public class SelectOperation extends AbstractJobOperation {
 			columnInfos.add(ColumnInfo.create(column.getName(), column.getType().getLogicalType()));
 		}
 
-		return new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(
-				ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, jobId.toString().length()))),
-			Collections.singletonList(Row.of(jobId.toString())));
+		return ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, jobId.toString().length())))
+			.data(Row.of(jobId.toString()))
+			.build();
 	}
 
 	@Override

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
@@ -26,6 +26,7 @@ import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapterFactory;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.result.BatchResult;
 import com.ververica.flink.table.gateway.result.ChangelogResult;
@@ -93,6 +94,7 @@ public class SelectOperation extends AbstractJobOperation {
 		}
 
 		return new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(
 				ColumnInfo.create(ConstantNames.JOB_ID, new VarCharType(false, jobId.toString().length()))),
 			Collections.singletonList(Row.of(jobId.toString())));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
@@ -23,6 +23,7 @@ import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -68,6 +69,7 @@ public class SetOperation implements NonJobOperation {
 			buildResult(env.getConfiguration().asMap(), data, maxKeyLenAndMaxValueLen);
 
 			return new ResultSet(
+				ResultKind.SUCCESS_WITH_CONTENT,
 				Arrays.asList(
 					ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, maxKeyLenAndMaxValueLen.f0)),
 					ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, maxKeyLenAndMaxValueLen.f1))),

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
@@ -90,7 +90,7 @@ public class SetOperation implements NonJobOperation {
 				.build();
 			context.setExecutionContext(newExecutionContext);
 
-			return OperationUtil.AFFECTED_ROW_COUNT0;
+			return OperationUtil.OK;
 		}
 	}
 

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -68,12 +67,13 @@ public class SetOperation implements NonJobOperation {
 			buildResult(env.getDeployment().asTopLevelMap(), data, maxKeyLenAndMaxValueLen);
 			buildResult(env.getConfiguration().asMap(), data, maxKeyLenAndMaxValueLen);
 
-			return new ResultSet(
-				ResultKind.SUCCESS_WITH_CONTENT,
-				Arrays.asList(
+			return ResultSet.builder()
+				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+				.columns(
 					ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, maxKeyLenAndMaxValueLen.f0)),
-					ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, maxKeyLenAndMaxValueLen.f1))),
-				data);
+					ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, maxKeyLenAndMaxValueLen.f1)))
+				.data(data)
+				.build();
 		} else {
 			// TODO avoid to build a new Environment for some cases
 			// set a property

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowTableOperation.java
@@ -69,12 +69,13 @@ public class ShowTableOperation implements NonJobOperation {
 			}
 		}
 
-		return new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		return ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.TABLES, new VarCharType(false, maxNameLength)),
 				ColumnInfo.create(ConstantNames.TYPE, new VarCharType(
-					false, Math.max(ConstantNames.VIEW_TYPE.length(), ConstantNames.TABLE_TYPE.length())))),
-			rows);
+					false, Math.max(ConstantNames.VIEW_TYPE.length(), ConstantNames.TABLE_TYPE.length()))))
+			.data(rows)
+			.build();
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowTableOperation.java
@@ -24,6 +24,7 @@ import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.apache.flink.table.api.TableEnvironment;
@@ -69,6 +70,7 @@ public class ShowTableOperation implements NonJobOperation {
 		}
 
 		return new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.TABLES, new VarCharType(false, maxNameLength)),
 				ColumnInfo.create(ConstantNames.TYPE, new VarCharType(

--- a/src/main/java/com/ververica/flink/table/gateway/operation/UseCatalogOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/UseCatalogOperation.java
@@ -52,6 +52,6 @@ public class UseCatalogOperation implements NonJobOperation {
 			}
 		});
 
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperation.java
@@ -52,6 +52,6 @@ public class UseDatabaseOperation implements NonJobOperation {
 			}
 		});
 
-		return OperationUtil.AFFECTED_ROW_COUNT0;
+		return OperationUtil.OK;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
@@ -41,4 +41,6 @@ public class ConstantNames {
 	public static final String TYPE = "type";
 	public static final String TABLE_TYPE = "TABLE";
 	public static final String VIEW_TYPE = "VIEW";
+
+	public static final String OK = "OK";
 }

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
@@ -25,6 +25,7 @@ public class ConstantNames {
 
 	public static final String JOB_ID = "job_id";
 	public static final String AFFECTED_ROW_COUNT = "affected_row_count";
+	public static final String RESULT = "result";
 	public static final String MODULES = "modules";
 	public static final String CATALOG = "catalog";
 	public static final String CATALOGS = "catalogs";

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultKind.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultKind.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.table.gateway.rest.result;
+
+/**
+ * ResultKind defines the types of the result.
+ */
+public enum ResultKind {
+	// for DDL, DCL and statements with a simple "OK"
+	SUCCESS,
+
+	// rows with important content are available (DML, DQL)
+	SUCCESS_WITH_CONTENT
+}

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
@@ -26,6 +26,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotatio
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,11 +53,7 @@ public class ResultSet {
 	// true if the corresponding row is an append row, false if its a retract row
 	private final List<Boolean> changeFlags;
 
-	public ResultSet(ResultKind resultKind, List<ColumnInfo> columns, List<Row> data) {
-		this(resultKind, columns, data, null);
-	}
-
-	public ResultSet(
+	private ResultSet(
 		ResultKind resultKind,
 		List<ColumnInfo> columns,
 		List<Row> data,
@@ -119,5 +116,78 @@ public class ResultSet {
 			", data=" + data +
 			", changeFlags=" + changeFlags +
 			'}';
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for {@link ResultSet}.
+	 */
+	public static class Builder {
+		private ResultKind resultKind = null;
+		private List<ColumnInfo> columns = null;
+		private List<Row> data = null;
+		private List<Boolean> changeFlags = null;
+
+		private Builder() {
+
+		}
+
+		/**
+		 * Set {@link ResultKind}.
+		 */
+		public Builder resultKind(ResultKind resultKind) {
+			this.resultKind = resultKind;
+			return this;
+		}
+
+		/**
+		 * Set {@link ColumnInfo}s.
+		 */
+		public Builder columns(ColumnInfo... columns) {
+			this.columns = Arrays.asList(columns);
+			return this;
+		}
+
+		/**
+		 * Set {@link ColumnInfo}s.
+		 */
+		public Builder columns(List<ColumnInfo> columns) {
+			this.columns = columns;
+			return this;
+		}
+
+		/**
+		 * Set data.
+		 */
+		public Builder data(List<Row> data) {
+			this.data = data;
+			return this;
+		}
+
+		/**
+		 * Set data.
+		 */
+		public Builder data(Row... data) {
+			this.data = Arrays.asList(data);
+			return this;
+		}
+
+		/**
+		 * Set change flags.
+		 */
+		public Builder changeFlags(List<Boolean> changeFlags) {
+			this.changeFlags = changeFlags;
+			return this;
+		}
+
+		/**
+		 * Returns a {@link ResultSet} instance.
+		 */
+		public ResultSet build() {
+			return new ResultSet(resultKind, columns, data, changeFlags);
+		}
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
@@ -132,7 +132,6 @@ public class ResultSet {
 		private List<Boolean> changeFlags = null;
 
 		private Builder() {
-
 		}
 
 		/**

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSet.java
@@ -31,12 +31,18 @@ import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A set of statement execution result containing column infos, rows of data and change flags for streaming mode.
+ * A set of one statement execution result containing result kind, column infos,
+ * rows of data and change flags for streaming mode.
  */
 @JsonSerialize(using = ResultSetJsonSerializer.class)
 @JsonDeserialize(using = ResultSetJsonDeserializer.class)
 public class ResultSet {
+	static final String FIELD_NAME_RESULT_KIND = "result_kind";
+	static final String FIELD_NAME_COLUMNS = "columns";
+	static final String FIELD_NAME_DATA = "data";
+	static final String FIELD_NAME_CHANGE_FLAGS = "change_flags";
 
+	private final ResultKind resultKind;
 	private final List<ColumnInfo> columns;
 	private final List<Row> data;
 
@@ -46,11 +52,16 @@ public class ResultSet {
 	// true if the corresponding row is an append row, false if its a retract row
 	private final List<Boolean> changeFlags;
 
-	public ResultSet(List<ColumnInfo> columns, List<Row> data) {
-		this(columns, data, null);
+	public ResultSet(ResultKind resultKind, List<ColumnInfo> columns, List<Row> data) {
+		this(resultKind, columns, data, null);
 	}
 
-	public ResultSet(List<ColumnInfo> columns, List<Row> data, @Nullable List<Boolean> changeFlags) {
+	public ResultSet(
+		ResultKind resultKind,
+		List<ColumnInfo> columns,
+		List<Row> data,
+		@Nullable List<Boolean> changeFlags) {
+		this.resultKind = Preconditions.checkNotNull(resultKind, "resultKind must not be null");
 		this.columns = Preconditions.checkNotNull(columns, "columns must not be null");
 		this.data = Preconditions.checkNotNull(data, "data must not be null");
 		if (!data.isEmpty()) {
@@ -62,6 +73,10 @@ public class ResultSet {
 			Preconditions.checkArgument(data.size() == changeFlags.size(),
 				"the size of data and the size of changeFlags should be equal");
 		}
+	}
+
+	public ResultKind getResultKind() {
+		return resultKind;
 	}
 
 	public List<ColumnInfo> getColumns() {
@@ -85,20 +100,22 @@ public class ResultSet {
 			return false;
 		}
 		ResultSet resultSet = (ResultSet) o;
-		return columns.equals(resultSet.columns) &&
+		return resultKind.equals(resultSet.resultKind) &&
+			columns.equals(resultSet.columns) &&
 			data.equals(resultSet.data) &&
 			Objects.equals(changeFlags, resultSet.changeFlags);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(columns, data, changeFlags);
+		return Objects.hash(resultKind, columns, data, changeFlags);
 	}
 
 	@Override
 	public String toString() {
 		return "ResultSet{" +
-			"columns=" + columns +
+			"resultKind=" + resultKind +
+			", columns=" + columns +
 			", data=" + data +
 			", changeFlags=" + changeFlags +
 			'}';

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonDeserializer.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonDeserializer.java
@@ -97,7 +97,12 @@ public class ResultSetJsonDeserializer extends StdDeserializer<ResultSet> {
 			throw new JsonParseException(jsonParser, "Field data must be provided");
 		}
 
-		return new ResultSet(resultKind, columns, data, changeFlags);
+		return ResultSet.builder()
+			.resultKind(resultKind)
+			.columns(columns)
+			.data(data)
+			.changeFlags(changeFlags)
+			.build();
 	}
 
 	private List<Row> deserializeRows(

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonDeserializer.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonDeserializer.java
@@ -71,7 +71,7 @@ public class ResultSetJsonDeserializer extends StdDeserializer<ResultSet> {
 			resultKindParser.nextToken();
 			resultKind = ctx.readValue(resultKindParser, ResultKind.class);
 		} else {
-			throw new JsonParseException(jsonParser, "Field column must be provided");
+			throw new JsonParseException(jsonParser, "Field resultKind must be provided");
 		}
 
 		JsonNode columnNode = node.get(FIELD_NAME_COLUMNS);

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonSerializer.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ResultSetJsonSerializer.java
@@ -30,6 +30,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
+import static com.ververica.flink.table.gateway.rest.result.ResultSet.FIELD_NAME_CHANGE_FLAGS;
+import static com.ververica.flink.table.gateway.rest.result.ResultSet.FIELD_NAME_COLUMNS;
+import static com.ververica.flink.table.gateway.rest.result.ResultSet.FIELD_NAME_DATA;
+import static com.ververica.flink.table.gateway.rest.result.ResultSet.FIELD_NAME_RESULT_KIND;
+
 /**
  * Json serializer for {@link ResultSet}.
  */
@@ -46,9 +51,10 @@ public class ResultSetJsonSerializer extends StdSerializer<ResultSet> {
 		SerializerProvider serializerProvider) throws IOException {
 		jsonGenerator.writeStartObject();
 
-		serializerProvider.defaultSerializeField("columns", resultSet.getColumns(), jsonGenerator);
+		serializerProvider.defaultSerializeField(FIELD_NAME_RESULT_KIND, resultSet.getResultKind(), jsonGenerator);
+		serializerProvider.defaultSerializeField(FIELD_NAME_COLUMNS, resultSet.getColumns(), jsonGenerator);
 
-		jsonGenerator.writeFieldName("data");
+		jsonGenerator.writeFieldName(FIELD_NAME_DATA);
 		jsonGenerator.writeStartArray();
 		for (Row row : resultSet.getData()) {
 			serializeRow(row, jsonGenerator, serializerProvider);
@@ -56,7 +62,7 @@ public class ResultSetJsonSerializer extends StdSerializer<ResultSet> {
 		jsonGenerator.writeEndArray();
 
 		if (resultSet.getChangeFlags().isPresent()) {
-			serializerProvider.defaultSerializeField("change_flags", resultSet.getChangeFlags().get(), jsonGenerator);
+			serializerProvider.defaultSerializeField(FIELD_NAME_CHANGE_FLAGS, resultSet.getChangeFlags().get(), jsonGenerator);
 		}
 
 		jsonGenerator.writeEndObject();

--- a/src/test/java/com/ververica/flink/table/gateway/operation/CreateViewOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/CreateViewOperationTest.java
@@ -35,7 +35,7 @@ public class CreateViewOperationTest extends OperationTestBase {
 	public void testCreateView() {
 		CreateViewOperation operation = new CreateViewOperation(context, "MyView1", "select 1 + 1");
 		ResultSet resultSet = operation.execute();
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, resultSet);
+		assertEquals(OperationUtil.OK, resultSet);
 
 		String[] tables = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyView1" }, tables);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DDLOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DDLOperationTest.java
@@ -46,7 +46,7 @@ public class DDLOperationTest extends OperationTestBase {
 			")\n";
 		DDLOperation operation = new DDLOperation(context, String.format(ddlTemplate, "MyTable1"), CREATE_TABLE);
 		ResultSet resultSet = operation.execute();
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, resultSet);
+		assertEquals(OperationUtil.OK, resultSet);
 
 		String[] tables = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyTable1" }, tables);
@@ -58,7 +58,7 @@ public class DDLOperationTest extends OperationTestBase {
 		assertEquals(0, tables1.length);
 
 		DDLOperation operation1 = new DDLOperation(context, "DROP TABLE IF EXISTS MyTable1", DROP_TABLE);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation1.execute());
+		assertEquals(OperationUtil.OK, operation1.execute());
 
 		final String ddlTemplate = "create table %s(\n" +
 			"  a int,\n" +
@@ -70,13 +70,13 @@ public class DDLOperationTest extends OperationTestBase {
 			"  'connector.path'='xxx'\n" +
 			")\n";
 		DDLOperation operation = new DDLOperation(context, String.format(ddlTemplate, "MyTable1"), CREATE_TABLE);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation.execute());
+		assertEquals(OperationUtil.OK, operation.execute());
 
 		String[] tables2 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyTable1" }, tables2);
 
 		DDLOperation operation2 = new DDLOperation(context, "DROP TABLE MyTable1", DROP_TABLE);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation2.execute());
+		assertEquals(OperationUtil.OK, operation2.execute());
 
 		String[] tables3 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertEquals(0, tables3.length);
@@ -85,7 +85,7 @@ public class DDLOperationTest extends OperationTestBase {
 	@Test
 	public void testCreateDatabase() {
 		DDLOperation operation = new DDLOperation(context, "create database MyDatabase1", CREATE_DATABASE);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation.execute());
+		assertEquals(OperationUtil.OK, operation.execute());
 
 		String[] tables2 = context.getExecutionContext().getTableEnvironment().listDatabases();
 		assertArrayEquals(new String[] { "default_database", "MyDatabase1" }, tables2);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DescribeOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DescribeOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.rest.result.TableSchemaUtil;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
@@ -66,6 +67,7 @@ public class DescribeOperationTest extends OperationTestBase {
 		String schemaJson = TableSchemaUtil.writeTableSchemaToJson(tableSchema);
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(
 				ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, schemaJson.length()))),
 			Collections.singletonList(Row.of(schemaJson))

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DescribeOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DescribeOperationTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,12 +65,11 @@ public class DescribeOperationTest extends OperationTestBase {
 			.build();
 		String schemaJson = TableSchemaUtil.writeTableSchemaToJson(tableSchema);
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(
-				ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, schemaJson.length()))),
-			Collections.singletonList(Row.of(schemaJson))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, schemaJson.length())))
+			.data(Row.of(schemaJson))
+			.build();
 
 		assertEquals(expected, resultSet);
 	}

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DropViewOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DropViewOperationTest.java
@@ -33,13 +33,13 @@ public class DropViewOperationTest extends OperationTestBase {
 	@Test
 	public void testDropView() {
 		CreateViewOperation operation1 = new CreateViewOperation(context, "MyView1", "select 1 + 1");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation1.execute());
+		assertEquals(OperationUtil.OK, operation1.execute());
 
 		String[] tables1 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyView1" }, tables1);
 
 		DropViewOperation operation2 = new DropViewOperation(context, "MyView1", false);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation2.execute());
+		assertEquals(OperationUtil.OK, operation2.execute());
 
 		String[] tables2 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertEquals(0, tables2.length);
@@ -48,19 +48,19 @@ public class DropViewOperationTest extends OperationTestBase {
 	@Test
 	public void testDropViewIfExists() {
 		CreateViewOperation operation1 = new CreateViewOperation(context, "MyView1", "select 1 + 1");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation1.execute());
+		assertEquals(OperationUtil.OK, operation1.execute());
 
 		String[] tables1 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyView1" }, tables1);
 
 		DropViewOperation operation2 = new DropViewOperation(context, "RandomString", true);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation2.execute());
+		assertEquals(OperationUtil.OK, operation2.execute());
 
 		String[] tables2 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertArrayEquals(new String[] { "MyView1" }, tables2);
 
 		DropViewOperation operation3 = new DropViewOperation(context, "MyView1", true);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation3.execute());
+		assertEquals(OperationUtil.OK, operation3.execute());
 
 		String[] tables3 = context.getExecutionContext().getTableEnvironment().listTables();
 		assertEquals(0, tables3.length);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ExplainOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ExplainOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -75,12 +74,11 @@ public class ExplainOperationTest extends OperationTestBase {
 			"\t\texchange_mode : PIPELINED\n" +
 			"\t\tPartitioning : RANDOM_PARTITIONED\n" +
 			"\n";
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(
-				ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, expectedExplain.length()))),
-			Collections.singletonList(Row.of(expectedExplain))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, expectedExplain.length())))
+			.data(Row.of(expectedExplain))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ExplainOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ExplainOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -75,6 +76,7 @@ public class ExplainOperationTest extends OperationTestBase {
 			"\t\tPartitioning : RANDOM_PARTITIONED\n" +
 			"\n";
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(
 				ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, expectedExplain.length()))),
 			Collections.singletonList(Row.of(expectedExplain))

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -69,6 +70,7 @@ public class ResetOperationTest extends OperationTestBase {
 		conf.setString("table.optimizer.join-reorder-enabled", "false");
 
 		ResultSet expected1 = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
 				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
@@ -92,6 +94,7 @@ public class ResetOperationTest extends OperationTestBase {
 		SetOperation showSetOperation2 = new SetOperation(context);
 		ResultSet resultSet2 = showSetOperation2.execute();
 		ResultSet expected2 = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
 				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
@@ -69,12 +69,14 @@ public class ResetOperationTest extends OperationTestBase {
 		Configuration conf = new Configuration();
 		conf.setString("table.optimizer.join-reorder-enabled", "false");
 
-		ResultSet expected1 = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected1 = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
-			properties);
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+			.data(properties)
+			.build();
+
 		assertEquals(expected1, resultSet);
 		assertEquals(conf, context.getExecutionContext().getTableEnvironment().getConfig().getConfiguration());
 
@@ -93,12 +95,14 @@ public class ResetOperationTest extends OperationTestBase {
 
 		SetOperation showSetOperation2 = new SetOperation(context);
 		ResultSet resultSet2 = showSetOperation2.execute();
-		ResultSet expected2 = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected2 = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
-			properties);
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+			.data(properties)
+			.build();
+
 		assertEquals(expected2, resultSet2);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
@@ -79,16 +79,16 @@ public class ResetOperationTest extends OperationTestBase {
 		assertEquals(conf, context.getExecutionContext().getTableEnvironment().getConfig().getConfiguration());
 
 		SetOperation setOperation1 = new SetOperation(context, "table.optimizer.join-reorder-enabled", "true");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation1.execute());
+		assertEquals(OperationUtil.OK, setOperation1.execute());
 		SetOperation setOperation2 = new SetOperation(context, "table.optimizer.join.broadcast-threshold", "TWO_PHASE");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation2.execute());
+		assertEquals(OperationUtil.OK, setOperation2.execute());
 		Configuration newConf = new Configuration(conf);
 		newConf.setString("table.optimizer.join-reorder-enabled", "true");
 		newConf.setString("table.optimizer.join.broadcast-threshold", "TWO_PHASE");
 		assertEquals(newConf, context.getExecutionContext().getTableEnvironment().getConfig().getConfiguration());
 
 		ResetOperation resetOperation = new ResetOperation(context);
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, resetOperation.execute());
+		assertEquals(OperationUtil.OK, resetOperation.execute());
 		assertEquals(conf, context.getExecutionContext().getTableEnvironment().getConfig().getConfiguration());
 
 		SetOperation showSetOperation2 = new SetOperation(context);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -60,6 +61,7 @@ public class SetOperationTest extends OperationTestBase {
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
 				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
@@ -82,6 +84,7 @@ public class SetOperationTest extends OperationTestBase {
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
 				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
@@ -101,6 +104,7 @@ public class SetOperationTest extends OperationTestBase {
 		SetOperation operation = new SetOperation(context);
 		ResultSet resultSet = operation.execute();
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
 				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
@@ -56,7 +56,7 @@ public class SetOperationTest extends OperationTestBase {
 	@Test
 	public void testSetProperties() {
 		SetOperation setOperation = new SetOperation(context, "table.optimizer.join-reorder-enabled", "true");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation.execute());
+		assertEquals(OperationUtil.OK, setOperation.execute());
 
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
@@ -79,7 +79,7 @@ public class SetOperationTest extends OperationTestBase {
 	@Test
 	public void testSetPropertiesWithWhitespace() {
 		SetOperation setOperation = new SetOperation(context, "execution.parallelism", " 10");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation.execute());
+		assertEquals(OperationUtil.OK, setOperation.execute());
 
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
@@ -129,7 +129,7 @@ public class SetOperationTest extends OperationTestBase {
 
 		// set table config key-value
 		SetOperation setOperation = new SetOperation(context, "table.optimizer.agg-phase-strategy", "ONE_PHASE");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, setOperation.execute());
+		assertEquals(OperationUtil.OK, setOperation.execute());
 		assertEquals("ONE_PHASE", context.getExecutionContext().getEnvironment().getConfiguration().asMap()
 			.getOrDefault("table.optimizer.agg-phase-strategy", null));
 		assertEquals("ONE_PHASE", context.getExecutionContext().getTableEnvironment()

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,19 +59,19 @@ public class SetOperationTest extends OperationTestBase {
 
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
-			Arrays.asList(
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),
 				Row.of("execution.parallelism", "1"),
 				Row.of("execution.type", "batch"),
 				Row.of("deployment.response-timeout", "5000"),
 				Row.of("table.optimizer.join-reorder-enabled", "true"))
-		);
+			.build();
 		assertEquals(expected, resultSet);
 	}
 
@@ -83,19 +82,19 @@ public class SetOperationTest extends OperationTestBase {
 
 		SetOperation showSetOperation = new SetOperation(context);
 		ResultSet resultSet = showSetOperation.execute();
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
-			Arrays.asList(
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),
 				Row.of("execution.parallelism", "10"),
 				Row.of("execution.type", "batch"),
 				Row.of("deployment.response-timeout", "5000"),
 				Row.of("table.optimizer.join-reorder-enabled", "false"))
-		);
+			.build();
 		assertEquals(expected, resultSet);
 	}
 
@@ -103,19 +102,19 @@ public class SetOperationTest extends OperationTestBase {
 	public void testShowProperties() {
 		SetOperation operation = new SetOperation(context);
 		ResultSet resultSet = operation.execute();
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5))),
-			Arrays.asList(
+				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),
 				Row.of("execution.parallelism", "1"),
 				Row.of("execution.type", "batch"),
 				Row.of("deployment.response-timeout", "5000"),
 				Row.of("table.optimizer.join-reorder-enabled", "false"))
-		);
+			.build();
 		assertEquals(expected, resultSet);
 	}
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogOperationTest.java
@@ -30,8 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,11 +56,11 @@ public class ShowCatalogOperationTest extends OperationTestBase {
 		ShowCatalogOperation operation = new ShowCatalogOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(ColumnInfo.create(ConstantNames.CATALOGS, new VarCharType(false, 15))),
-			Arrays.asList(Row.of("catalog1"), Row.of("default_catalog"), Row.of("simple-catalog"))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.CATALOGS, new VarCharType(false, 15)))
+			.data(Row.of("catalog1"), Row.of("default_catalog"), Row.of("simple-catalog"))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -58,6 +59,7 @@ public class ShowCatalogOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(ColumnInfo.create(ConstantNames.CATALOGS, new VarCharType(false, 15))),
 			Arrays.asList(Row.of("catalog1"), Row.of("default_catalog"), Row.of("simple-catalog"))
 		);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,11 +58,11 @@ public class ShowCurrentCatalogOperationTest extends OperationTestBase {
 		ShowCurrentCatalogOperation operation = new ShowCurrentCatalogOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(ColumnInfo.create(ConstantNames.CATALOG, new VarCharType(false, 14))),
-			Collections.singletonList(Row.of("simple-catalog"))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.CATALOG, new VarCharType(false, 14)))
+			.data(Row.of("simple-catalog"))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -59,6 +60,7 @@ public class ShowCurrentCatalogOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(ColumnInfo.create(ConstantNames.CATALOG, new VarCharType(false, 14))),
 			Collections.singletonList(Row.of("simple-catalog"))
 		);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,11 +59,11 @@ public class ShowCurrentDatabaseOperationTest extends OperationTestBase {
 		ShowCurrentDatabaseOperation operation = new ShowCurrentDatabaseOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(ColumnInfo.create(ConstantNames.DATABASE, new VarCharType(false, 7))),
-			Collections.singletonList(Row.of("default"))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.DATABASE, new VarCharType(false, 7)))
+			.data(Row.of("default"))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -60,6 +61,7 @@ public class ShowCurrentDatabaseOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(ColumnInfo.create(ConstantNames.DATABASE, new VarCharType(false, 7))),
 			Collections.singletonList(Row.of("default"))
 		);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabaseOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,11 +58,11 @@ public class ShowDatabaseOperationTest extends OperationTestBase {
 		ShowDatabaseOperation operation = new ShowDatabaseOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(ColumnInfo.create(ConstantNames.DATABASES, new VarCharType(false, 7))),
-			Collections.singletonList(Row.of("default"))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.DATABASES, new VarCharType(false, 7)))
+			.data(Row.of("default"))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabaseOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -59,6 +60,7 @@ public class ShowDatabaseOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(ColumnInfo.create(ConstantNames.DATABASES, new VarCharType(false, 7))),
 			Collections.singletonList(Row.of("default"))
 		);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowModuleOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowModuleOperationTest.java
@@ -30,8 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,11 +55,11 @@ public class ShowModuleOperationTest extends OperationTestBase {
 		ShowModuleOperation operation = new ShowModuleOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Collections.singletonList(ColumnInfo.create(ConstantNames.MODULES, new VarCharType(false, 8))),
-			Arrays.asList(Row.of("core"), Row.of("mymodule"), Row.of("myhive"), Row.of("myhive2"))
-		);
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(ColumnInfo.create(ConstantNames.MODULES, new VarCharType(false, 8)))
+			.data(Row.of("core"), Row.of("mymodule"), Row.of("myhive"), Row.of("myhive2"))
+			.build();
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowModuleOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowModuleOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -57,6 +58,7 @@ public class ShowModuleOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Collections.singletonList(ColumnInfo.create(ConstantNames.MODULES, new VarCharType(false, 8))),
 			Arrays.asList(Row.of("core"), Row.of("mymodule"), Row.of("myhive"), Row.of("myhive2"))
 		);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowTableOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowTableOperationTest.java
@@ -21,6 +21,7 @@ package com.ververica.flink.table.gateway.operation;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
+import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
@@ -57,6 +58,7 @@ public class ShowTableOperationTest extends OperationTestBase {
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = new ResultSet(
+			ResultKind.SUCCESS_WITH_CONTENT,
 			Arrays.asList(
 				ColumnInfo.create(ConstantNames.TABLES, new VarCharType(false, 15)),
 				ColumnInfo.create(ConstantNames.TYPE, new VarCharType(false, 5))),

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowTableOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowTableOperationTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,19 +56,19 @@ public class ShowTableOperationTest extends OperationTestBase {
 		ShowTableOperation operation = new ShowTableOperation(context);
 		ResultSet resultSet = operation.execute();
 
-		ResultSet expected = new ResultSet(
-			ResultKind.SUCCESS_WITH_CONTENT,
-			Arrays.asList(
+		ResultSet expected = ResultSet.builder()
+			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+			.columns(
 				ColumnInfo.create(ConstantNames.TABLES, new VarCharType(false, 15)),
-				ColumnInfo.create(ConstantNames.TYPE, new VarCharType(false, 5))),
-			Arrays.asList(
+				ColumnInfo.create(ConstantNames.TYPE, new VarCharType(false, 5)))
+			.data(
 				Row.of("TestView1", "VIEW"),
 				Row.of("TestView2", "VIEW"),
 				Row.of("TableNumber1", "TABLE"),
 				Row.of("TableNumber2", "TABLE"),
-				Row.of("TableSourceSink", "TABLE")
-			)
-		);
+				Row.of("TableSourceSink", "TABLE"))
+			.build();
+
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/UseCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/UseCatalogOperationTest.java
@@ -47,7 +47,7 @@ public class UseCatalogOperationTest extends OperationTestBase {
 	@Test
 	public void testUseCatalog() {
 		UseCatalogOperation operation = new UseCatalogOperation(context, "simple-catalog");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation.execute());
+		assertEquals(OperationUtil.OK, operation.execute());
 
 		assertEquals("simple-catalog", context.getExecutionContext().getTableEnvironment().getCurrentCatalog());
 	}

--- a/src/test/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperationTest.java
@@ -49,7 +49,7 @@ public class UseDatabaseOperationTest extends OperationTestBase {
 		context.getExecutionContext().getTableEnvironment().useCatalog("catalog1");
 
 		UseDatabaseOperation operation = new UseDatabaseOperation(context, "default");
-		assertEquals(OperationUtil.AFFECTED_ROW_COUNT0, operation.execute());
+		assertEquals(OperationUtil.OK, operation.execute());
 
 		assertEquals("default", context.getExecutionContext().getTableEnvironment().getCurrentDatabase());
 	}


### PR DESCRIPTION
1. add ResultKind for statement execution result based on [FLIP-84](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=134745878)
2. return "OK" instead of `affected_row_count` for DDL/SET/RESET/USE based on [FLIP-84](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=134745878)
3. Introduce ResultSet.Builder to create ResultSet instance