### PR TITLE
Parse reset, describe and explain statements with SQL parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ The following statements are supported now.
 | DROP VIEW view_name ... | Drop a table with given name |
 | SET xx=yy | Set given key's session property to the specific value |
 | SET | List all session's properties |
-| RESET | Reset all session's properties set by `SET` command |
-| DESCRIBE table_name | Show the schema of a table |
-| EXPLAIN ... | Show string-based explanation about AST and execution plan of the given statement |
+| RESET ALL | Reset all session's properties set by `SET` command |
+| DESCRIBE table_name<br>DESCRIBE TABLE table_name | Show the schema of a table |
+| EXPLAIN PLAN FOR ... | Show string-based explanation about AST and execution plan of the given statement |
 | SELECT ... | Submit a Flink `SELECT` SQL job |
 | INSERT INTO ... | Submit a Flink `INSERT INTO` SQL job |
 | INSERT OVERWRITE ... | Submit a Flink `INSERT OVERWRITE` SQL job |

--- a/README.md
+++ b/README.md
@@ -172,9 +172,7 @@ The following statements are supported now.
 |  statement   | comment  |
 |  ----  | ----  |
 | SHOW CATALOGS | List all registered catalogs |
-| SHOW CURRENT CATALOG | Show current catalog (experimental) |
 | SHOW DATABASES | List all databases in the current catalog |
-| SHOW CURRENT DATABASE | Show current database in current catalog (experimental) |
 | SHOW TABLES | List all tables in the current database of the current catalog |
 | SHOW FUNCTIONS | List all functions |
 | SHOW MODULES | List all modules |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The following statements are supported now.
 | SET xx=yy | Set given key's session property to the specific value |
 | SET | List all session's properties |
 | RESET ALL | Reset all session's properties set by `SET` command |
-| DESCRIBE table_name<br>DESCRIBE TABLE table_name | Show the schema of a table |
+| DESCRIBE [TABLE] table_name | Show the schema of a table |
 | EXPLAIN PLAN FOR ... | Show string-based explanation about AST and execution plan of the given statement |
 | SELECT ... | Submit a Flink `SELECT` SQL job |
 | INSERT INTO ... | Submit a Flink `INSERT INTO` SQL job |

--- a/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
@@ -29,6 +29,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropView;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
+import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
 import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
 import org.apache.flink.sql.parser.dql.SqlShowFunctions;
@@ -195,9 +196,14 @@ public final class SqlCommandParser {
 		} else if (node instanceof SqlUseDatabase) {
 			cmd = SqlCommand.USE;
 			operands = new String[] { ((SqlUseDatabase) node).getDatabaseName().toString() };
-		} else if (node instanceof SqlDescribeTable) {
+		} else if (node instanceof SqlDescribeTable || node instanceof SqlRichDescribeTable) {
 			cmd = SqlCommand.DESCRIBE_TABLE;
-			operands = new String[]{((SqlDescribeTable) node).getTable().toString()};
+			if (node instanceof SqlDescribeTable) {
+				operands = new String[] { ((SqlDescribeTable) node).getTable().toString() };
+			} else {
+				// TODO describe extended
+				operands = new String[] { String.join(".", ((SqlRichDescribeTable) node).fullTableName()) };
+			}
 		} else if (node instanceof SqlExplain) {
 			cmd = SqlCommand.EXPLAIN;
 			// TODO support explain details

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
@@ -36,13 +36,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Operation for DESCRIBE command.
+ * Operation for DESCRIBE_TABLE command.
  */
-public class DescribeOperation implements NonJobOperation {
+public class DescribeTableOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
 	private final String tableName;
 
-	public DescribeOperation(SessionContext context, String tableName) {
+	public DescribeTableOperation(SessionContext context, String tableName) {
 		this.context = context.getExecutionContext();
 		this.tableName = tableName;
 	}

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
@@ -19,6 +19,7 @@
 package com.ververica.flink.table.gateway.operation;
 
 import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
+import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.SessionContext;
 
 /**
@@ -57,6 +58,9 @@ public class OperationFactory {
 				}
 				break;
 			case RESET:
+				if (call.operands.length > 0) {
+					throw new SqlGatewayException("Only RESET ALL is supported now");
+				}
 				operation = new ResetOperation(context);
 				break;
 			case USE_CATALOG:
@@ -90,14 +94,14 @@ public class OperationFactory {
 			case SHOW_FUNCTIONS:
 				operation = new ShowFunctionOperation(context);
 				break;
-			case DESCRIBE:
-				operation = new DescribeOperation(context, call.operands[0]);
+			case DESCRIBE_TABLE:
+				operation = new DescribeTableOperation(context, call.operands[0]);
 				break;
 			case EXPLAIN:
 				operation = new ExplainOperation(context, call.operands[0]);
 				break;
 			default:
-				throw new RuntimeException("Unsupported command call " + call + ". This is a bug.");
+				throw new SqlGatewayException("Unsupported command call " + call + ". This is a bug.");
 		}
 
 		return operation;

--- a/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
@@ -249,12 +249,21 @@ public class SqlCommandParserTest {
 	}
 
 	@Test
-	public void testDescribeTable() {
-		String query2 = "describe table MyTable";
-		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "MyTable");
+	public void testDescribe() {
+		String query1 = "describe MyTable";
+		checkCommand(query1, SqlCommand.DESCRIBE_TABLE, "MyTable");
 
-		String query3 = "\n -- comments \n describe \n -- comments \n table  MyTable; -- comments";
-		checkCommand(query3, SqlCommand.DESCRIBE_TABLE, "MyTable");
+		String query2 = "\n -- comments \n describe \n -- comments \n  MyTable; -- comments";
+		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "MyTable");
+	}
+
+	@Test
+	public void testDescribeTable() {
+		String query1 = "describe table MyTable";
+		checkCommand(query1, SqlCommand.DESCRIBE_TABLE, "MyTable");
+
+		String query2 = "\n -- comments \n describe \n -- comments \n table  MyTable; -- comments";
+		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "MyTable");
 	}
 
 	@Test

--- a/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
@@ -115,8 +115,8 @@ public class DependencyTest {
 		SessionManager sessionManager = new SessionManager(defaultContext);
 		String sessionId = sessionManager.createSession("test", "blink", "streaming", Maps.newConcurrentMap());
 		Session session = sessionManager.getSession(sessionId);
-		Tuple2<ResultSet, SqlCommand> result = session.runStatement("DESCRIBE TableNumber1");
-		assertEquals(SqlCommand.DESCRIBE, result.f1);
+		Tuple2<ResultSet, SqlCommand> result = session.runStatement("DESCRIBE TABLE TableNumber1");
+		assertEquals(SqlCommand.DESCRIBE_TABLE, result.f1);
 		String schemaJson = result.f0.getData().get(0).getField(0).toString();
 		TableSchema schema = TableSchemaUtil.readTableSchemaFromJson(schemaJson);
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DescribeTableOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DescribeTableOperationTest.java
@@ -31,9 +31,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Tests for {@link DescribeOperation}.
+ * Tests for {@link DescribeTableOperation}.
  */
-public class DescribeOperationTest extends OperationTestBase {
+public class DescribeTableOperationTest extends OperationTestBase {
 
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
 
@@ -48,7 +48,7 @@ public class DescribeOperationTest extends OperationTestBase {
 
 	@Test
 	public void testDescribe() throws Exception {
-		DescribeOperation operation = new DescribeOperation(context, "TableNumber1");
+		DescribeTableOperation operation = new DescribeTableOperation(context, "TableNumber1");
 		ResultSet resultSet = operation.execute();
 
 		TableSchema tableSchema = TableSchema.builder()

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
@@ -87,7 +87,7 @@ public class OperationWithUserJarTest extends OperationTestBase {
 	public void testDescribe() throws Exception {
 		createUserDefinedSource(context, "R");
 
-		DescribeOperation operation = new DescribeOperation(context, "R");
+		DescribeTableOperation operation = new DescribeTableOperation(context, "R");
 		ResultSet resultSet = operation.execute();
 
 		TableSchema tableSchema = TableSchema.builder()


### PR DESCRIPTION
Previously we parse `reset`, `describe` and `explain` statements with regexps, which does not support parsing multiple statements and comments, and is also not standard.

This PR parses `reset`, `describe` and `explain` statements with SQL parser. SQL parser recognize these three commands in a slightly different way:
* `RESET` should now be written as `RESET ALL`
* `DESCRIBE` can also be written as `DESCRIBE TABLE`
* `EXPLAIN` should now be written as `EXPLAIN PLAN FOR`