### PR TITLE
Fix table name escaping in DescribeTableOperation and remove "DESCRIBE TABLE" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The following statements are supported now.
 | SET xx=yy | Set given key's session property to the specific value |
 | SET | List all session's properties |
 | RESET ALL | Reset all session's properties set by `SET` command |
-| DESCRIBE [TABLE] table_name | Show the schema of a table |
+| DESCRIBE table_name | Show the schema of a table |
 | EXPLAIN PLAN FOR ... | Show string-based explanation about AST and execution plan of the given statement |
 | SELECT ... | Submit a Flink `SELECT` SQL job |
 | INSERT INTO ... | Submit a Flink `INSERT INTO` SQL job |

--- a/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
@@ -38,7 +38,6 @@ import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
 
 import org.apache.calcite.config.Lex;
-import org.apache.calcite.sql.SqlDescribeTable;
 import org.apache.calcite.sql.SqlDrop;
 import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlKind;
@@ -196,14 +195,18 @@ public final class SqlCommandParser {
 		} else if (node instanceof SqlUseDatabase) {
 			cmd = SqlCommand.USE;
 			operands = new String[] { ((SqlUseDatabase) node).getDatabaseName().toString() };
-		} else if (node instanceof SqlDescribeTable || node instanceof SqlRichDescribeTable) {
+		} else if (node instanceof SqlRichDescribeTable) {
 			cmd = SqlCommand.DESCRIBE_TABLE;
-			if (node instanceof SqlDescribeTable) {
-				operands = new String[] { ((SqlDescribeTable) node).getTable().toString() };
-			} else {
-				// TODO describe extended
-				operands = new String[] { String.join(".", ((SqlRichDescribeTable) node).fullTableName()) };
+			// TODO support describe extended
+			String[] fullTableName = ((SqlRichDescribeTable) node).fullTableName();
+			StringBuilder escapedNameBuilder = new StringBuilder();
+			for (int i = 0; i < fullTableName.length; i++) {
+				if (i > 0) {
+					escapedNameBuilder.append('.');
+				}
+				escapedNameBuilder.append('`').append(fullTableName[i]).append('`');
 			}
+			operands = new String[] { escapedNameBuilder.toString() };
 		} else if (node instanceof SqlExplain) {
 			cmd = SqlCommand.EXPLAIN;
 			// TODO support explain details

--- a/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlCommandParser.java
@@ -53,6 +53,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Simple parser for determining the type of command and its parameters.
@@ -199,14 +201,9 @@ public final class SqlCommandParser {
 			cmd = SqlCommand.DESCRIBE_TABLE;
 			// TODO support describe extended
 			String[] fullTableName = ((SqlRichDescribeTable) node).fullTableName();
-			StringBuilder escapedNameBuilder = new StringBuilder();
-			for (int i = 0; i < fullTableName.length; i++) {
-				if (i > 0) {
-					escapedNameBuilder.append('.');
-				}
-				escapedNameBuilder.append('`').append(fullTableName[i]).append('`');
-			}
-			operands = new String[] { escapedNameBuilder.toString() };
+			String escapedName =
+				Stream.of(fullTableName).map(s -> "`" + s + "`").collect(Collectors.joining("."));
+			operands = new String[] { escapedName };
 		} else if (node instanceof SqlExplain) {
 			cmd = SqlCommand.EXPLAIN;
 			// TODO support explain details

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
@@ -51,7 +51,7 @@ public class DescribeTableOperation implements NonJobOperation {
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		try {
-			TableSchema schema = context.wrapClassLoader(() -> tableEnv.scan(tableName).getSchema());
+			TableSchema schema = context.wrapClassLoader(() -> tableEnv.from(tableName).getSchema());
 			String schemaJson = TableSchemaUtil.writeTableSchemaToJson(schema);
 			int length = schemaJson.length();
 			List<Row> data = new ArrayList<>();

--- a/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/SqlCommandParserTest.java
@@ -251,19 +251,13 @@ public class SqlCommandParserTest {
 	@Test
 	public void testDescribe() {
 		String query1 = "describe MyTable";
-		checkCommand(query1, SqlCommand.DESCRIBE_TABLE, "MyTable");
+		checkCommand(query1, SqlCommand.DESCRIBE_TABLE, "`MyTable`");
 
 		String query2 = "\n -- comments \n describe \n -- comments \n  MyTable; -- comments";
-		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "MyTable");
-	}
+		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "`MyTable`");
 
-	@Test
-	public void testDescribeTable() {
-		String query1 = "describe table MyTable";
-		checkCommand(query1, SqlCommand.DESCRIBE_TABLE, "MyTable");
-
-		String query2 = "\n -- comments \n describe \n -- comments \n table  MyTable; -- comments";
-		checkCommand(query2, SqlCommand.DESCRIBE_TABLE, "MyTable");
+		String query3 = "describe `my.catalog`.mydb.`my.table`";
+		checkCommand(query3, SqlCommand.DESCRIBE_TABLE, "`my.catalog`.`mydb`.`my.table`");
 	}
 
 	@Test

--- a/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
@@ -115,7 +115,7 @@ public class DependencyTest {
 		SessionManager sessionManager = new SessionManager(defaultContext);
 		String sessionId = sessionManager.createSession("test", "blink", "streaming", Maps.newConcurrentMap());
 		Session session = sessionManager.getSession(sessionId);
-		Tuple2<ResultSet, SqlCommand> result = session.runStatement("DESCRIBE TABLE TableNumber1");
+		Tuple2<ResultSet, SqlCommand> result = session.runStatement("DESCRIBE TableNumber1");
 		assertEquals(SqlCommand.DESCRIBE_TABLE, result.f1);
 		String schemaJson = result.f0.getData().get(0).getField(0).toString();
 		TableSchema schema = TableSchemaUtil.readTableSchemaFromJson(schemaJson);


### PR DESCRIPTION
This PR fixes #37 by escaping table name in `DescribeTableOperation`.

This PR also removes `DESCRIBE TABLE table_name` support (can only use `DESCRIBE table_name` now), because
* [FLIP-69](https://cwiki.apache.org/confluence/display/FLINK/FLIP+69+-+Flink+SQL+DDL+Enhancement) is not going to introduce this statement.
* `SqlDescribeTable` is removed from Flink 1.11, and its functionality is totally covered by `SqlRichDescribeTable`.