### PR TITLE
Support multiple users can share the same gateway server

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/Session.java
+++ b/src/main/java/com/ververica/flink/table/gateway/Session.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,7 +73,11 @@ public class Session {
 		return context;
 	}
 
-	public Tuple2<ResultSet, SqlCommandParser.SqlCommand> runStatement(String statement) {
+	public Tuple2<ResultSet, SqlCommandParser.SqlCommand> runStatement(String statement){
+		return this.runStatement(statement, Collections.emptyMap());
+	}
+
+	public Tuple2<ResultSet, SqlCommandParser.SqlCommand> runStatement(String statement, Map<String, String> operationConf) {
 		LOG.info("Session: {}, run statement: {}", sessionId, statement);
 		boolean isBlinkPlanner = context.getExecutionContext().getEnvironment().getExecution().getPlanner()
 			.equalsIgnoreCase(ExecutionEntry.EXECUTION_PLANNER_VALUE_BLINK);
@@ -91,7 +96,7 @@ public class Session {
 			throw new SqlGatewayException(e.getMessage(), e.getCause());
 		}
 
-		Operation operation = OperationFactory.createOperation(call, context);
+		Operation operation = OperationFactory.createOperation(call, context, operationConf);
 		ResultSet resultSet = operation.execute();
 
 		if (operation instanceof JobOperation) {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
@@ -22,17 +22,19 @@ import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
 import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.SessionContext;
 
+import java.util.Map;
+
 /**
  * The factory to create {@link Operation} based on {@link SqlCommandCall}.
  */
 public class OperationFactory {
 
-	public static Operation createOperation(SqlCommandCall call, SessionContext context) {
+	public static Operation createOperation(SqlCommandCall call, SessionContext context, Map<String, String> operationConf) {
 
 		Operation operation;
 		switch (call.command) {
 			case SELECT:
-				operation = new SelectOperation(context, call.operands[0]);
+				operation = new SelectOperation(context, call.operands[0], operationConf);
 				break;
 			case CREATE_VIEW:
 				operation = new CreateViewOperation(context, call.operands[0], call.operands[1]);
@@ -71,7 +73,7 @@ public class OperationFactory {
 				break;
 			case INSERT_INTO:
 			case INSERT_OVERWRITE:
-				operation = new InsertOperation(context, call.operands[0]);
+				operation = new InsertOperation(context, call.operands[0], operationConf);
 				break;
 			case SHOW_MODULES:
 				operation = new ShowModuleOperation(context);

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/StatementExecuteHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/StatementExecuteHandler.java
@@ -76,9 +76,10 @@ public class StatementExecuteHandler
 
 		// TODO supports this
 		Long executionTimeoutMillis = request.getRequestBody().getExecutionTimeout();
+		Map<String, String> executionConf = request.getRequestBody().getExecutionConf();
 
 		try {
-			Tuple2<ResultSet, SqlCommand> tuple2 = sessionManager.getSession(sessionId).runStatement(statement);
+			Tuple2<ResultSet, SqlCommand> tuple2 = sessionManager.getSession(sessionId).runStatement(statement, executionConf);
 			ResultSet resultSet = tuple2.f0;
 			String statementType = tuple2.f1.name();
 

--- a/src/main/java/com/ververica/flink/table/gateway/rest/message/StatementExecuteRequestBody.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/message/StatementExecuteRequestBody.java
@@ -26,6 +26,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import javax.annotation.Nullable;
 
+import java.util.Map;
+
 /**
  * {@link RequestBody} for executing a statement.
  */
@@ -34,6 +36,7 @@ public class StatementExecuteRequestBody implements RequestBody {
 
 	private static final String FIELD_STATEMENT = "statement";
 	private static final String FIELD_EXECUTION_TIMEOUT = "execution_timeout";
+	private static final String FIELD_EXECUTION_CONF = "execution_conf";
 
 	@JsonProperty(FIELD_STATEMENT)
 	@Nullable
@@ -43,11 +46,16 @@ public class StatementExecuteRequestBody implements RequestBody {
 	@Nullable
 	private Long executionTimeout;
 
+	@JsonProperty(FIELD_EXECUTION_CONF)
+	private Map<String, String> executionConf;
+
 	public StatementExecuteRequestBody(
 		@Nullable @JsonProperty(FIELD_STATEMENT) String statement,
-		@Nullable @JsonProperty(FIELD_EXECUTION_TIMEOUT) Long executionTimeout) {
+		@Nullable @JsonProperty(FIELD_EXECUTION_TIMEOUT) Long executionTimeout,
+		@JsonProperty(FIELD_EXECUTION_CONF) Map<String, String> executionConf) {
 		this.statement = statement;
 		this.executionTimeout = executionTimeout;
+		this.executionConf = executionConf;
 	}
 
 	@Nullable
@@ -60,5 +68,10 @@ public class StatementExecuteRequestBody implements RequestBody {
 	@JsonIgnore
 	public Long getExecutionTimeout() {
 		return executionTimeout;
+	}
+
+	@JsonIgnore
+	public Map<String, String> getExecutionConf() {
+		return executionConf;
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/security/HadoopSecurityContext.java
+++ b/src/main/java/com/ververica/flink/table/gateway/security/HadoopSecurityContext.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.table.gateway.security;
+
+import org.apache.flink.runtime.security.SecurityContext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+
+/**
+ * An implementation of SecurityContext for secure cluster.
+ */
+public class HadoopSecurityContext implements SecurityContext {
+	private final String user;
+
+	public HadoopSecurityContext(String user) {
+		this.user = user;
+	}
+
+	@Override
+	public <T> T runSecured(Callable<T> securedCallable) throws Exception {
+		UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+		if (StringUtils.isNotEmpty(user)){
+			ugi = UserGroupInformation.createProxyUser(user, UserGroupInformation.getCurrentUser());
+			return ugi.doAs((PrivilegedExceptionAction<T>) securedCallable::call);
+		}
+		return ugi.doAs((PrivilegedExceptionAction<T>) securedCallable::call);
+	}
+}

--- a/src/main/java/com/ververica/flink/table/gateway/security/NoOpSecurityContext.java
+++ b/src/main/java/com/ververica/flink/table/gateway/security/NoOpSecurityContext.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.table.gateway.security;
+
+import org.apache.flink.runtime.security.SecurityContext;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Callable;
+
+/**
+ * An implementation of SecurityContext for insecure cluster.
+ */
+public class NoOpSecurityContext implements SecurityContext {
+	private final String user;
+
+	public NoOpSecurityContext(String user) {
+		this.user = user;
+	}
+
+	@Override
+	public <T> T runSecured(Callable<T> securedCallable) throws Exception {
+		if (StringUtils.isNotEmpty(user)){
+			UserGroupInformation ugi = UserGroupInformation.createRemoteUser(user);
+			return ugi.doAs((PrivilegedExceptionAction<T>) securedCallable::call);
+		}
+		return securedCallable.call();
+	}
+}


### PR DESCRIPTION
This PR added support for multiple users can share the same gateway server in yarn per-job mode.

1. Added `execution_conf` (not required) contains parameter `proxyUser` to `StatementExecuteRequestBody`, for example:

   ```json
   {
    "statement":"SELECT * FROM source",
    "execution_conf":{
      "proxyUser":"user1"
    }
   }
   ```

2. In an insecure cluster, the yarn application will be submitted to cluster by `proxyUser` if specified.

3. In a secure cluster, login from keytab via `SecurityUtils.install` and a proxy user ugi object is created with `proxyUser`, if `proxyUser` is not specified, submitted job by login user.
