### PR TITLE
Clean up code base

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/GatewayOptions.java
+++ b/src/main/java/com/ververica/flink/table/gateway/GatewayOptions.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway.options;
+package com.ververica.flink.table.gateway;
 
 import javax.annotation.Nullable;
 
@@ -36,11 +36,11 @@ public class GatewayOptions {
 	private final List<URL> libraryDirs;
 
 	public GatewayOptions(
-		boolean isPrintHelp,
-		@Nullable Integer port,
-		@Nullable URL defaultConfig,
-		@Nullable List<URL> jars,
-		@Nullable List<URL> libraryDirs) {
+			boolean isPrintHelp,
+			@Nullable Integer port,
+			@Nullable URL defaultConfig,
+			@Nullable List<URL> jars,
+			@Nullable List<URL> libraryDirs) {
 		this.isPrintHelp = isPrintHelp;
 		this.port = port;
 		this.defaultConfig = defaultConfig;

--- a/src/main/java/com/ververica/flink/table/gateway/GatewayOptionsParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/GatewayOptionsParser.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway.options;
+package com.ververica.flink.table.gateway;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.core.fs.Path;
 

--- a/src/main/java/com/ververica/flink/table/gateway/SqlGateway.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlGateway.java
@@ -20,9 +20,9 @@ package com.ververica.flink.table.gateway;
 
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.context.DefaultContext;
-import com.ververica.flink.table.gateway.options.GatewayOptions;
-import com.ververica.flink.table.gateway.options.GatewayOptionsParser;
 import com.ververica.flink.table.gateway.rest.SqlGatewayEndpoint;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;

--- a/src/main/java/com/ververica/flink/table/gateway/config/Environment.java
+++ b/src/main/java/com/ververica/flink/table/gateway/config/Environment.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.config;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.entries.CatalogEntry;
 import com.ververica.flink.table.gateway.config.entries.ConfigurationEntry;
 import com.ververica.flink.table.gateway.config.entries.DeploymentEntry;
@@ -29,6 +28,7 @@ import com.ververica.flink.table.gateway.config.entries.ServerEntry;
 import com.ververica.flink.table.gateway.config.entries.SessionEntry;
 import com.ververica.flink.table.gateway.config.entries.TableEntry;
 import com.ververica.flink.table.gateway.config.entries.ViewEntry;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
 

--- a/src/main/java/com/ververica/flink/table/gateway/config/entries/ConfigEntry.java
+++ b/src/main/java/com/ververica/flink/table/gateway/config/entries/ConfigEntry.java
@@ -18,7 +18,7 @@
 
 package com.ververica.flink.table.gateway.config.entries;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;

--- a/src/main/java/com/ververica/flink/table/gateway/config/entries/TableEntry.java
+++ b/src/main/java/com/ververica/flink/table/gateway/config/entries/TableEntry.java
@@ -18,8 +18,8 @@
 
 package com.ververica.flink.table.gateway.config.entries;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.ConfigUtil;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.table.descriptors.DescriptorProperties;
 

--- a/src/main/java/com/ververica/flink/table/gateway/context/DefaultContext.java
+++ b/src/main/java/com/ververica/flink/table/gateway/context/DefaultContext.java
@@ -18,8 +18,8 @@
 
 package com.ververica.flink.table.gateway.context;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.Environment;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.client.cli.CliFrontend;

--- a/src/main/java/com/ververica/flink/table/gateway/context/ExecutionContext.java
+++ b/src/main/java/com/ververica/flink/table/gateway/context/ExecutionContext.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.context;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.DeploymentEntry;
 import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
@@ -27,6 +26,7 @@ import com.ververica.flink.table.gateway.config.entries.SourceSinkTableEntry;
 import com.ververica.flink.table.gateway.config.entries.SourceTableEntry;
 import com.ververica.flink.table.gateway.config.entries.TemporalTableEntry;
 import com.ververica.flink.table.gateway.config.entries.ViewEntry;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.time.Time;
@@ -133,13 +133,13 @@ public class ExecutionContext<ClusterID> {
 	private SessionState sessionState;
 
 	private ExecutionContext(
-		Environment environment,
-		@Nullable SessionState sessionState,
-		List<URL> dependencies,
-		Configuration flinkConfig,
-		ClusterClientServiceLoader clusterClientServiceLoader,
-		Options commandLineOptions,
-		List<CustomCommandLine> availableCommandLines) throws FlinkException {
+			Environment environment,
+			@Nullable SessionState sessionState,
+			List<URL> dependencies,
+			Configuration flinkConfig,
+			ClusterClientServiceLoader clusterClientServiceLoader,
+			Options commandLineOptions,
+			List<CustomCommandLine> availableCommandLines) throws FlinkException {
 		this.environment = environment;
 
 		this.flinkConfig = flinkConfig;
@@ -258,13 +258,13 @@ public class ExecutionContext<ClusterID> {
 
 	/** Returns a builder for this {@link ExecutionContext}. */
 	public static Builder builder(
-		Environment defaultEnv,
-		Environment sessionEnv,
-		List<URL> dependencies,
-		Configuration configuration,
-		ClusterClientServiceLoader serviceLoader,
-		Options commandLineOptions,
-		List<CustomCommandLine> commandLines) {
+			Environment defaultEnv,
+			Environment sessionEnv,
+			List<URL> dependencies,
+			Configuration configuration,
+			ClusterClientServiceLoader serviceLoader,
+			Options commandLineOptions,
+			List<CustomCommandLine> commandLines) {
 		return new Builder(defaultEnv, sessionEnv, dependencies, configuration,
 			serviceLoader, commandLineOptions, commandLines);
 	}
@@ -274,10 +274,10 @@ public class ExecutionContext<ClusterID> {
 	//------------------------------------------------------------------------------------------------------------------
 
 	private static Configuration createExecutionConfig(
-		CommandLine commandLine,
-		Options commandLineOptions,
-		List<CustomCommandLine> availableCommandLines,
-		List<URL> dependencies) throws FlinkException {
+			CommandLine commandLine,
+			Options commandLineOptions,
+			List<CustomCommandLine> availableCommandLines,
+			List<URL> dependencies) throws FlinkException {
 		LOG.debug("Available commandline options: {}", commandLineOptions);
 		List<String> options = Stream
 			.of(commandLine.getOptions())
@@ -371,14 +371,13 @@ public class ExecutionContext<ClusterID> {
 	}
 
 	private static TableEnvironment createStreamTableEnvironment(
-		StreamExecutionEnvironment env,
-		EnvironmentSettings settings,
-		TableConfig config,
-		Executor executor,
-		CatalogManager catalogManager,
-		ModuleManager moduleManager,
-		FunctionCatalog functionCatalog) {
-
+			StreamExecutionEnvironment env,
+			EnvironmentSettings settings,
+			TableConfig config,
+			Executor executor,
+			CatalogManager catalogManager,
+			ModuleManager moduleManager,
+			FunctionCatalog functionCatalog) {
 		final Map<String, String> plannerProperties = settings.toPlannerProperties();
 		final Planner planner = ComponentFactoryService.find(PlannerFactory.class, plannerProperties)
 			.create(plannerProperties, executor, config, functionCatalog, catalogManager);
@@ -395,8 +394,8 @@ public class ExecutionContext<ClusterID> {
 	}
 
 	private static Executor lookupExecutor(
-		Map<String, String> executorProperties,
-		StreamExecutionEnvironment executionEnvironment) {
+			Map<String, String> executorProperties,
+			StreamExecutionEnvironment executionEnvironment) {
 		try {
 			ExecutorFactory executorFactory = ComponentFactoryService.find(ExecutorFactory.class, executorProperties);
 			Method createMethod = executorFactory.getClass()
@@ -478,11 +477,11 @@ public class ExecutionContext<ClusterID> {
 	}
 
 	private void createTableEnvironment(
-		EnvironmentSettings settings,
-		TableConfig config,
-		CatalogManager catalogManager,
-		ModuleManager moduleManager,
-		FunctionCatalog functionCatalog) {
+			EnvironmentSettings settings,
+			TableConfig config,
+			CatalogManager catalogManager,
+			ModuleManager moduleManager,
+			FunctionCatalog functionCatalog) {
 		if (environment.getExecution().isStreamingPlanner()) {
 			streamExecEnv = createStreamExecutionEnvironment();
 			execEnv = null;
@@ -683,13 +682,13 @@ public class ExecutionContext<ClusterID> {
 		private SessionState sessionState;
 
 		private Builder(
-			Environment defaultEnv,
-			@Nullable Environment sessionEnv,
-			List<URL> dependencies,
-			Configuration configuration,
-			ClusterClientServiceLoader serviceLoader,
-			Options commandLineOptions,
-			List<CustomCommandLine> commandLines) {
+				Environment defaultEnv,
+				@Nullable Environment sessionEnv,
+				List<URL> dependencies,
+				Configuration configuration,
+				ClusterClientServiceLoader serviceLoader,
+				Options commandLineOptions,
+				List<CustomCommandLine> commandLines) {
 			this.defaultEnv = defaultEnv;
 			this.sessionEnv = sessionEnv;
 			this.dependencies = dependencies;
@@ -733,18 +732,18 @@ public class ExecutionContext<ClusterID> {
 		public final FunctionCatalog functionCatalog;
 
 		private SessionState(
-			CatalogManager catalogManager,
-			ModuleManager moduleManager,
-			FunctionCatalog functionCatalog) {
+				CatalogManager catalogManager,
+				ModuleManager moduleManager,
+				FunctionCatalog functionCatalog) {
 			this.catalogManager = catalogManager;
 			this.moduleManager = moduleManager;
 			this.functionCatalog = functionCatalog;
 		}
 
 		public static SessionState of(
-			CatalogManager catalogManager,
-			ModuleManager moduleManager,
-			FunctionCatalog functionCatalog) {
+				CatalogManager catalogManager,
+				ModuleManager moduleManager,
+				FunctionCatalog functionCatalog) {
 			return new SessionState(catalogManager, moduleManager, functionCatalog);
 		}
 	}

--- a/src/main/java/com/ververica/flink/table/gateway/context/SessionContext.java
+++ b/src/main/java/com/ververica/flink/table/gateway/context/SessionContext.java
@@ -36,10 +36,10 @@ public class SessionContext {
 	private ExecutionContext<?> executionContext;
 
 	public SessionContext(
-		@Nullable String sessionName,
-		String sessionId,
-		Environment originalSessionEnv,
-		DefaultContext defaultContext) {
+			@Nullable String sessionName,
+			String sessionId,
+			Environment originalSessionEnv,
+			DefaultContext defaultContext) {
 		this.sessionName = sessionName;
 		this.sessionId = sessionId;
 		this.originalSessionEnv = originalSessionEnv;

--- a/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapter.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapter.java
@@ -18,9 +18,9 @@
 
 package com.ververica.flink.table.gateway.deployment;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;

--- a/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapterFactory.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/ClusterDescriptorAdapterFactory.java
@@ -35,7 +35,6 @@ public class ClusterDescriptorAdapterFactory {
 			Configuration configuration,
 			String sessionId,
 			JobID jobId) {
-
 		String executionTarget = executionContext.getFlinkConfig().getString(DeploymentOptions.TARGET);
 		if (executionTarget == null) {
 			throw new RuntimeException("No execution.target specified in your configuration file.");

--- a/src/main/java/com/ververica/flink/table/gateway/deployment/ProgramDeployer.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/ProgramDeployer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.deployment;
 
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.configuration.Configuration;
@@ -50,9 +50,9 @@ public class ProgramDeployer {
 	 * @param pipeline Flink {@link Pipeline} to execute
 	 */
 	public ProgramDeployer(
-		Configuration configuration,
-		String jobName,
-		Pipeline pipeline) {
+			Configuration configuration,
+			String jobName,
+			Pipeline pipeline) {
 		this.configuration = configuration;
 		this.pipeline = pipeline;
 		this.jobName = jobName;

--- a/src/main/java/com/ververica/flink/table/gateway/deployment/YarnPerJobClusterDescriptorAdapter.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/YarnPerJobClusterDescriptorAdapter.java
@@ -35,10 +35,10 @@ public class YarnPerJobClusterDescriptorAdapter<ClusterID> extends ClusterDescri
 	private static final Logger LOG = LoggerFactory.getLogger(YarnPerJobClusterDescriptorAdapter.class);
 
 	public YarnPerJobClusterDescriptorAdapter(
-		ExecutionContext<ClusterID> executionContext,
-		Configuration configuration,
-		String sessionId,
-		JobID jobId) {
+			ExecutionContext<ClusterID> executionContext,
+			Configuration configuration,
+			String sessionId,
+			JobID jobId) {
 		super(executionContext, configuration, sessionId, jobId);
 	}
 

--- a/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/AbstractJobOperation.java
@@ -18,12 +18,12 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapter;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/CreateViewOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/CreateViewOperation.java
@@ -18,13 +18,13 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.TableEntry;
 import com.ververica.flink.table.gateway.config.entries.ViewEntry;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.TableEnvironment;
 

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DDLOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DDLOperation.java
@@ -18,11 +18,11 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand;
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.StreamQueryConfig;
 import org.apache.flink.table.api.TableEnvironment;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
@@ -26,6 +25,7 @@ import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.rest.result.TableSchemaUtil;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Operation for DESCRIBE_TABLE command.
+ * Operation for DESCRIBE TABLE command.
  */
 public class DescribeTableOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
@@ -59,7 +59,8 @@ public class DescribeTableOperation implements NonJobOperation {
 
 			return ResultSet.builder()
 				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-				.columns(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, length)))
+				.columns(
+					ColumnInfo.create(ConstantNames.DESCRIBE_RESULT, new VarCharType(false, length)))
 				.data(data)
 				.build();
 		} catch (Throwable t) {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DropViewOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DropViewOperation.java
@@ -18,13 +18,13 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.TableEntry;
 import com.ververica.flink.table.gateway.config.entries.ViewEntry;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 /**
  * Operation for DROP VIEW command.

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ExplainOperation.java
@@ -18,13 +18,13 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -52,7 +52,7 @@ public class ExplainOperation implements NonJobOperation {
 			String explanation = context.wrapClassLoader(() -> tableEnv.explain(table));
 			return ResultSet.builder()
 				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-				.columns(ColumnInfo.create(ConstantNames.EXPLANATION, new VarCharType(false, explanation.length())))
+				.columns(ColumnInfo.create(ConstantNames.EXPLAIN_RESULT, new VarCharType(false, explanation.length())))
 				.data(Row.of(explanation))
 				.build();
 		} catch (Throwable t) {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
@@ -18,15 +18,15 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.ProgramDeployer;
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapterFactory;
+import com.ververica.flink.table.gateway.deployment.ProgramDeployer;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
@@ -18,9 +18,9 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.SessionContext;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommandCall;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 /**
  * The factory to create {@link Operation} based on {@link SqlCommandCall}.
@@ -74,28 +74,28 @@ public class OperationFactory {
 				operation = new InsertOperation(context, call.operands[0]);
 				break;
 			case SHOW_MODULES:
-				operation = new ShowModuleOperation(context);
+				operation = new ShowModulesOperation(context);
 				break;
 			case SHOW_CATALOGS:
-				operation = new ShowCatalogOperation(context);
+				operation = new ShowCatalogsOperation(context);
 				break;
 			case SHOW_CURRENT_CATALOG:
 				operation = new ShowCurrentCatalogOperation(context);
 				break;
 			case SHOW_DATABASES:
-				operation = new ShowDatabaseOperation(context);
+				operation = new ShowDatabasesOperation(context);
 				break;
 			case SHOW_CURRENT_DATABASE:
 				operation = new ShowCurrentDatabaseOperation(context);
 				break;
 			case SHOW_TABLES:
-				operation = new ShowTableOperation(context);
+				operation = new ShowTablesOperation(context);
 				break;
 			case SHOW_VIEWS:
-				operation = new ShowViewOperation(context);
+				operation = new ShowViewsOperation(context);
 				break;
 			case SHOW_FUNCTIONS:
-				operation = new ShowFunctionOperation(context);
+				operation = new ShowFunctionsOperation(context);
 				break;
 			case DESCRIBE_TABLE:
 				operation = new DescribeTableOperation(context, call.operands[0]);

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SelectOperation.java
@@ -18,12 +18,10 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.ProgramDeployer;
-import com.ververica.flink.table.gateway.SqlExecutionException;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.deployment.ClusterDescriptorAdapterFactory;
+import com.ververica.flink.table.gateway.deployment.ProgramDeployer;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
@@ -34,6 +32,8 @@ import com.ververica.flink.table.gateway.result.Result;
 import com.ververica.flink.table.gateway.result.ResultDescriptor;
 import com.ververica.flink.table.gateway.result.ResultUtil;
 import com.ververica.flink.table.gateway.result.TypedResult;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SetOperation.java
@@ -70,8 +70,8 @@ public class SetOperation implements NonJobOperation {
 			return ResultSet.builder()
 				.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 				.columns(
-					ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, maxKeyLenAndMaxValueLen.f0)),
-					ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, maxKeyLenAndMaxValueLen.f1)))
+					ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, maxKeyLenAndMaxValueLen.f0)),
+					ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, maxKeyLenAndMaxValueLen.f1)))
 				.data(data)
 				.build();
 		} else {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowCatalogsOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowCatalogsOperation.java
@@ -18,50 +18,30 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.config.entries.TableEntry;
-import com.ververica.flink.table.gateway.config.entries.ViewEntry;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
-import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
-import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
-import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.api.TableEnvironment;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Operation for SHOW VIEW command.
+ * Operation for SHOW CATALOGS command.
  */
-public class ShowViewOperation implements NonJobOperation {
-
+public class ShowCatalogsOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
 
-	public ShowViewOperation(SessionContext context) {
+	public ShowCatalogsOperation(SessionContext context) {
 		this.context = context.getExecutionContext();
 	}
 
 	@Override
 	public ResultSet execute() {
-		List<Row> rows = new ArrayList<>();
-		int maxNameLength = 1;
-
-		for (Map.Entry<String, TableEntry> entry : context.getEnvironment().getTables().entrySet()) {
-			if (entry.getValue() instanceof ViewEntry) {
-				String name = entry.getKey();
-				rows.add(Row.of(name));
-				maxNameLength = Math.max(maxNameLength, name.length());
-			}
-		}
-
-		return ResultSet.builder()
-			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.VIEWS, new VarCharType(false, maxNameLength)))
-			.data(rows)
-			.build();
+		final TableEnvironment tableEnv = context.getTableEnvironment();
+		final List<String> catalogs = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listCatalogs()));
+		return OperationUtil.stringListToResultSet(catalogs, ConstantNames.SHOW_CATALOGS_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperation.java
@@ -39,6 +39,6 @@ public class ShowCurrentCatalogOperation implements NonJobOperation {
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		return OperationUtil.singleStringToResultSet(
-			context.wrapClassLoader(tableEnv::getCurrentCatalog), ConstantNames.CATALOG);
+			context.wrapClassLoader(tableEnv::getCurrentCatalog), ConstantNames.SHOW_CURRENT_CATALOG_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperation.java
@@ -39,6 +39,6 @@ public class ShowCurrentDatabaseOperation implements NonJobOperation {
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		return OperationUtil.singleStringToResultSet(
-			context.wrapClassLoader(tableEnv::getCurrentDatabase), ConstantNames.DATABASE);
+			context.wrapClassLoader(tableEnv::getCurrentDatabase), ConstantNames.SHOW_CURRENT_DATABASE_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowDatabasesOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowDatabasesOperation.java
@@ -29,12 +29,12 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Operation for SHOW DATABASE command.
+ * Operation for SHOW DATABASES command.
  */
-public class ShowDatabaseOperation implements NonJobOperation {
+public class ShowDatabasesOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
 
-	public ShowDatabaseOperation(SessionContext context) {
+	public ShowDatabasesOperation(SessionContext context) {
 		this.context = context.getExecutionContext();
 	}
 
@@ -42,6 +42,6 @@ public class ShowDatabaseOperation implements NonJobOperation {
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
 		final List<String> databases = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listDatabases()));
-		return OperationUtil.stringListToResultSet(databases, ConstantNames.DATABASES);
+		return OperationUtil.stringListToResultSet(databases, ConstantNames.SHOW_DATABASES_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowFunctionsOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowFunctionsOperation.java
@@ -29,19 +29,19 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Operation for SHOW CATALOG command.
+ * Operation for SHOW FUNCTIONS command.
  */
-public class ShowCatalogOperation implements NonJobOperation {
+public class ShowFunctionsOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
 
-	public ShowCatalogOperation(SessionContext context) {
+	public ShowFunctionsOperation(SessionContext context) {
 		this.context = context.getExecutionContext();
 	}
 
 	@Override
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
-		final List<String> catalogs = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listCatalogs()));
-		return OperationUtil.stringListToResultSet(catalogs, ConstantNames.CATALOGS);
+		final List<String> functions = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFunctions()));
+		return OperationUtil.stringListToResultSet(functions, ConstantNames.SHOW_FUNCTIONS_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowModulesOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowModulesOperation.java
@@ -29,19 +29,19 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Operation for SHOW FUNCTION command.
+ * Operation for SHOW MODULES command.
  */
-public class ShowFunctionOperation implements NonJobOperation {
+public class ShowModulesOperation implements NonJobOperation {
 	private final ExecutionContext<?> context;
 
-	public ShowFunctionOperation(SessionContext context) {
+	public ShowModulesOperation(SessionContext context) {
 		this.context = context.getExecutionContext();
 	}
 
 	@Override
 	public ResultSet execute() {
 		final TableEnvironment tableEnv = context.getTableEnvironment();
-		final List<String> functions = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFunctions()));
-		return OperationUtil.stringListToResultSet(functions, ConstantNames.FUNCTIONS);
+		final List<String> modules = context.wrapClassLoader(() -> Arrays.asList(tableEnv.listModules()));
+		return OperationUtil.stringListToResultSet(modules, ConstantNames.SHOW_MODULES_RESULT);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/ShowTablesOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/ShowTablesOperation.java
@@ -18,49 +18,47 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.config.Environment;
+import com.ververica.flink.table.gateway.context.ExecutionContext;
+import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ColumnInfo;
 import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
-import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
 
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
- * Tests for {@link ShowCatalogOperation}.
+ * Operation for SHOW TABLES command.
  */
-public class ShowCatalogOperationTest extends OperationTestBase {
+public class ShowTablesOperation implements NonJobOperation {
+	private final ExecutionContext<?> context;
 
-	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
-
-	@Override
-	protected Environment getSessionEnvironment() throws Exception {
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", "old");
-		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
-		replaceVars.put("$VAR_UPDATE_MODE", "");
-		return EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
+	public ShowTablesOperation(SessionContext context) {
+		this.context = context.getExecutionContext();
 	}
 
-	@Test
-	public void testShowCatalog() {
-		ShowCatalogOperation operation = new ShowCatalogOperation(context);
-		ResultSet resultSet = operation.execute();
+	@Override
+	public ResultSet execute() {
+		List<Row> rows = new ArrayList<>();
+		int maxNameLength = 1;
 
-		ResultSet expected = ResultSet.builder()
+		final TableEnvironment tableEnv = context.getTableEnvironment();
+		// listTables will return all tables and views
+		for (String table : context.wrapClassLoader(() -> Arrays.asList(tableEnv.listTables()))) {
+			rows.add(Row.of(table));
+			maxNameLength = Math.max(maxNameLength, table.length());
+		}
+
+		return ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.CATALOGS, new VarCharType(false, 15)))
-			.data(Row.of("catalog1"), Row.of("default_catalog"), Row.of("simple-catalog"))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_TABLES_RESULT, new VarCharType(false, maxNameLength)))
+			.data(rows)
 			.build();
-		assertEquals(expected, resultSet);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.operation;
 
 import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
 import org.apache.flink.sql.parser.ddl.SqlAlterTable;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SqlParseException.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SqlParseException.java
@@ -16,20 +16,20 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.operation;
 
 /**
- * Exception thrown in gateway.
+ * Exception thrown during parsing SQL statement.
  */
-public class SqlGatewayException extends RuntimeException {
+public class SqlParseException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public SqlGatewayException(String msg) {
-		super(msg);
+	public SqlParseException(String message) {
+		super(message);
 	}
 
-	public SqlGatewayException(String msg, Throwable cause) {
-		super(msg, cause);
+	public SqlParseException(String message, Throwable e) {
+		super(message, e);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/operation/UseCatalogOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/UseCatalogOperation.java
@@ -18,10 +18,10 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.exceptions.CatalogException;

--- a/src/main/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/UseDatabaseOperation.java
@@ -18,10 +18,10 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.exceptions.CatalogException;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/SqlGatewayEndpoint.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/SqlGatewayEndpoint.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.rest;
 
-import com.ververica.flink.table.gateway.SessionManager;
 import com.ververica.flink.table.gateway.rest.handler.GetInfoHandler;
 import com.ververica.flink.table.gateway.rest.handler.GetInfoHeaders;
 import com.ververica.flink.table.gateway.rest.handler.JobCancelHandler;
@@ -35,6 +34,7 @@ import com.ververica.flink.table.gateway.rest.handler.SessionHeartbeatHandler;
 import com.ververica.flink.table.gateway.rest.handler.SessionHeartbeatHeaders;
 import com.ververica.flink.table.gateway.rest.handler.StatementExecuteHandler;
 import com.ververica.flink.table.gateway.rest.handler.StatementExecuteHeaders;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/JobCancelHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/JobCancelHandler.java
@@ -18,12 +18,12 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.rest.message.JobCancelResponseBody;
 import com.ververica.flink.table.gateway.rest.message.JobIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionJobMessageParameters;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/JobStatusHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/JobStatusHandler.java
@@ -18,12 +18,12 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.rest.message.JobIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.JobStatusResponseBody;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionJobMessageParameters;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/ResultFetchHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/ResultFetchHandler.java
@@ -18,9 +18,6 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.Session;
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.rest.message.JobIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.ResultFetchMessageParameters;
 import com.ververica.flink.table.gateway.rest.message.ResultFetchRequestBody;
@@ -28,6 +25,9 @@ import com.ververica.flink.table.gateway.rest.message.ResultFetchResponseBody;
 import com.ververica.flink.table.gateway.rest.message.ResultTokenPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.rest.session.Session;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionCloseHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionCloseHandler.java
@@ -18,11 +18,11 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.rest.message.SessionCloseResponseBody;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionMessageParameters;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionCreateHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionCreateHandler.java
@@ -18,11 +18,11 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
 import com.ververica.flink.table.gateway.rest.message.SessionCreateRequestBody;
 import com.ververica.flink.table.gateway.rest.message.SessionCreateResponseBody;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionHeartbeatHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/SessionHeartbeatHandler.java
@@ -18,10 +18,10 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionMessageParameters;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/handler/StatementExecuteHandler.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/handler/StatementExecuteHandler.java
@@ -18,14 +18,14 @@
 
 package com.ververica.flink.table.gateway.rest.handler;
 
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand;
-import com.ververica.flink.table.gateway.SqlGatewayException;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand;
 import com.ververica.flink.table.gateway.rest.message.SessionIdPathParameter;
 import com.ververica.flink.table.gateway.rest.message.SessionMessageParameters;
 import com.ververica.flink.table.gateway.rest.message.StatementExecuteRequestBody;
 import com.ververica.flink.table.gateway.rest.message.StatementExecuteResponseBody;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/message/SessionIdPathParameter.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/message/SessionIdPathParameter.java
@@ -18,7 +18,7 @@
 
 package com.ververica.flink.table.gateway.rest.message;
 
-import com.ververica.flink.table.gateway.SessionID;
+import com.ververica.flink.table.gateway.rest.session.SessionID;
 
 import org.apache.flink.runtime.rest.messages.ConversionException;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
@@ -23,21 +23,36 @@ package com.ververica.flink.table.gateway.rest.result;
  */
 public class ConstantNames {
 
+	// for statement execution
 	public static final String JOB_ID = "job_id";
-	public static final String AFFECTED_ROW_COUNT = "affected_row_count";
-	public static final String RESULT = "result";
-	public static final String MODULES = "modules";
-	public static final String CATALOG = "catalog";
-	public static final String CATALOGS = "catalogs";
-	public static final String DATABASE = "database";
-	public static final String DATABASES = "databases";
-	public static final String FUNCTIONS = "functions";
-	public static final String EXPLANATION = "explanation";
-	public static final String SCHEMA = "schema";
-	public static final String TABLES = "tables";
-	public static final String VIEWS = "views";
-	public static final String KEY = "key";
-	public static final String VALUE = "value";
 
+	// for DMLs
+	public static final String AFFECTED_ROW_COUNT = "affected_row_count";
+
+	// for results with SUCCESS result kind
+	public static final String RESULT = "result";
 	public static final String OK = "OK";
+
+	public static final String SHOW_MODULES_RESULT = "modules";
+
+	public static final String SHOW_CURRENT_CATALOG_RESULT = "catalog";
+
+	public static final String SHOW_CATALOGS_RESULT = "catalogs";
+
+	public static final String SHOW_CURRENT_DATABASE_RESULT = "database";
+
+	public static final String SHOW_DATABASES_RESULT = "databases";
+
+	public static final String SHOW_FUNCTIONS_RESULT = "functions";
+
+	public static final String EXPLAIN_RESULT = "explanation";
+
+	public static final String DESCRIBE_RESULT = "schema";
+
+	public static final String SHOW_TABLES_RESULT = "tables";
+
+	public static final String SHOW_VIEWS_RESULT = "views";
+
+	public static final String SET_KEY = "key";
+	public static final String SET_VALUE = "value";
 }

--- a/src/main/java/com/ververica/flink/table/gateway/rest/session/Session.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/session/Session.java
@@ -16,15 +16,18 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.rest.session;
 
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
 import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.operation.JobOperation;
 import com.ververica.flink.table.gateway.operation.Operation;
 import com.ververica.flink.table.gateway.operation.OperationFactory;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommandCall;
+import com.ververica.flink.table.gateway.operation.SqlParseException;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/session/SessionID.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/session/SessionID.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.rest.session;
 
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.StringUtils;

--- a/src/main/java/com/ververica/flink/table/gateway/rest/session/SessionManager.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/session/SessionManager.java
@@ -16,12 +16,13 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.rest.session;
 
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
 import com.ververica.flink.table.gateway.context.DefaultContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/ververica/flink/table/gateway/result/BatchResult.java
+++ b/src/main/java/com/ververica/flink/table/gateway/result/BatchResult.java
@@ -18,8 +18,8 @@
 
 package com.ververica.flink.table.gateway.result;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
 import com.ververica.flink.table.gateway.sink.CollectBatchTableSink;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -56,11 +56,10 @@ public class BatchResult<C> extends AbstractResult<C, Row> {
 	private boolean allResultRetrieved = false;
 
 	public BatchResult(
-		TableSchema tableSchema,
-		RowTypeInfo outputType,
-		ExecutionConfig config,
-		ClassLoader classLoader) {
-
+			TableSchema tableSchema,
+			RowTypeInfo outputType,
+			ExecutionConfig config,
+			ClassLoader classLoader) {
 		// TODO supports large result set
 		accumulatorName = new AbstractID().toString();
 		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config), tableSchema);

--- a/src/main/java/com/ververica/flink/table/gateway/result/ChangelogResult.java
+++ b/src/main/java/com/ververica/flink/table/gateway/result/ChangelogResult.java
@@ -18,9 +18,9 @@
 
 package com.ververica.flink.table.gateway.result;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.sink.CollectStreamTableSink;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
@@ -65,14 +65,13 @@ public class ChangelogResult<C> extends AbstractResult<C, Tuple2<Boolean, Row>> 
 	private final int maxBufferSize;
 
 	public ChangelogResult(
-		RowTypeInfo outputType,
-		TableSchema tableSchema,
-		ExecutionConfig config,
-		InetAddress gatewayAddress,
-		int gatewayPort,
-		ClassLoader classLoader,
-		int maxBufferSize) {
-
+			RowTypeInfo outputType,
+			TableSchema tableSchema,
+			ExecutionConfig config,
+			InetAddress gatewayAddress,
+			int gatewayPort,
+			ClassLoader classLoader,
+			int maxBufferSize) {
 		resultLock = new Object();
 
 		// create socket stream iterator

--- a/src/main/java/com/ververica/flink/table/gateway/result/ResultUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/result/ResultUtil.java
@@ -18,9 +18,9 @@
 
 package com.ververica.flink.table.gateway.result;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.DeploymentEntry;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -42,9 +42,9 @@ import java.util.stream.Stream;
 public class ResultUtil {
 
 	public static <C> BatchResult<C> createBatchResult(
-		TableSchema schema,
-		ExecutionConfig config,
-		ClassLoader classLoader) {
+			TableSchema schema,
+			ExecutionConfig config,
+			ClassLoader classLoader) {
 		final TypeInformation[] schemaTypeInfos = Stream.of(schema.getFieldDataTypes())
 			.map(TypeInfoDataTypeConverter::fromDataTypeToTypeInfo)
 			.toArray(TypeInformation[]::new);
@@ -54,11 +54,11 @@ public class ResultUtil {
 	}
 
 	public static <C> ChangelogResult<C> createChangelogResult(
-		Configuration flinkConfig,
-		Environment env,
-		TableSchema schema,
-		ExecutionConfig config,
-		ClassLoader classLoader) {
+			Configuration flinkConfig,
+			Environment env,
+			TableSchema schema,
+			ExecutionConfig config,
+			ClassLoader classLoader) {
 		final TypeInformation[] schemaTypeInfos = Stream.of(schema.getFieldDataTypes())
 			.map(TypeInfoDataTypeConverter::fromDataTypeToTypeInfo)
 			.toArray(TypeInformation[]::new);

--- a/src/main/java/com/ververica/flink/table/gateway/utils/BashJavaUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/utils/BashJavaUtil.java
@@ -18,10 +18,10 @@
 
 package com.ververica.flink.table.gateway.utils;
 
+import com.ververica.flink.table.gateway.GatewayOptions;
+import com.ververica.flink.table.gateway.GatewayOptionsParser;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.context.DefaultContext;
-import com.ververica.flink.table.gateway.options.GatewayOptions;
-import com.ververica.flink.table.gateway.options.GatewayOptionsParser;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -38,7 +38,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class BashJavaUtil {
 	private static final String EXECUTION_PREFIX = "BASH_JAVA_UTILS_EXEC_RESULT:";
 
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) {
 		checkArgument(args.length > 0, "Command not specified.");
 
 		switch (Command.valueOf(args[0])) {

--- a/src/main/java/com/ververica/flink/table/gateway/utils/EnvironmentUtil.java
+++ b/src/main/java/com/ververica/flink/table/gateway/utils/EnvironmentUtil.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.utils;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.config.Environment;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/ververica/flink/table/gateway/utils/SqlExecutionException.java
+++ b/src/main/java/com/ververica/flink/table/gateway/utils/SqlExecutionException.java
@@ -16,23 +16,20 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway.operation;
-
-import com.ververica.flink.table.gateway.rest.result.ResultSet;
-
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
+package com.ververica.flink.table.gateway.utils;
 
 /**
- * Tests for {@link ShowFunctionOperation}.
+ * Exception thrown during the execution of SQL statements.
  */
-public class ShowFunctionOperationTest extends OperationTestBase {
+public class SqlExecutionException extends RuntimeException {
 
-	@Test
-	public void testShowFunction() {
-		ShowFunctionOperation operation = new ShowFunctionOperation(context);
-		ResultSet resultSet = operation.execute();
-		assertTrue(resultSet.getData().size() > 0);
+	private static final long serialVersionUID = 1L;
+
+	public SqlExecutionException(String message) {
+		super(message);
+	}
+
+	public SqlExecutionException(String message, Throwable e) {
+		super(message, e);
 	}
 }

--- a/src/main/java/com/ververica/flink/table/gateway/utils/SqlGatewayException.java
+++ b/src/main/java/com/ververica/flink/table/gateway/utils/SqlGatewayException.java
@@ -16,20 +16,20 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.utils;
 
 /**
- * Exception thrown during the execution of SQL statements.
+ * Exception thrown in gateway.
  */
-public class SqlExecutionException extends RuntimeException {
+public class SqlGatewayException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public SqlExecutionException(String message) {
-		super(message);
+	public SqlGatewayException(String msg) {
+		super(msg);
 	}
 
-	public SqlExecutionException(String message, Throwable e) {
-		super(message, e);
+	public SqlGatewayException(String msg, Throwable cause) {
+		super(msg, cause);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
@@ -18,12 +18,12 @@
 
 package com.ververica.flink.table.gateway.config;
 
-import com.ververica.flink.table.gateway.Session;
-import com.ververica.flink.table.gateway.SessionManager;
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand;
 import com.ververica.flink.table.gateway.context.DefaultContext;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.rest.result.TableSchemaUtil;
+import com.ververica.flink.table.gateway.rest.session.Session;
+import com.ververica.flink.table.gateway.rest.session.SessionManager;
 import com.ververica.flink.table.gateway.sink.TestTableSinkFactoryBase;
 import com.ververica.flink.table.gateway.source.TestTableSourceFactoryBase;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;

--- a/src/test/java/com/ververica/flink/table/gateway/config/EnvironmentTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/EnvironmentTest.java
@@ -18,8 +18,8 @@
 
 package com.ververica.flink.table.gateway.config;
 
-import com.ververica.flink.table.gateway.SqlGatewayException;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
+import com.ververica.flink.table.gateway.utils.SqlGatewayException;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DDLOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DDLOperationTest.java
@@ -22,9 +22,9 @@ import com.ververica.flink.table.gateway.rest.result.ResultSet;
 
 import org.junit.Test;
 
-import static com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand.CREATE_DATABASE;
-import static com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand.CREATE_TABLE;
-import static com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand.DROP_TABLE;
+import static com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand.CREATE_DATABASE;
+import static com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand.CREATE_TABLE;
+import static com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand.DROP_TABLE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/DropViewOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/DropViewOperationTest.java
@@ -18,7 +18,7 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlExecutionException;
+import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 
 import org.junit.Test;
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestBase.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestBase.java
@@ -18,11 +18,11 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SessionID;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
 import com.ververica.flink.table.gateway.context.DefaultContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
+import com.ververica.flink.table.gateway.rest.session.SessionID;
 
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestUtils.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestUtils.java
@@ -40,7 +40,7 @@ public class OperationTestUtils {
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.SCHEMA, new VarCharType(false, schemaJson.length())))
+			.columns(ColumnInfo.create(ConstantNames.DESCRIBE_RESULT, new VarCharType(false, schemaJson.length())))
 			.data(Row.of(schemaJson))
 			.build();
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
@@ -18,7 +18,6 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlCommandParser;
 import com.ververica.flink.table.gateway.config.Environment;
 import com.ververica.flink.table.gateway.context.DefaultContext;
 import com.ververica.flink.table.gateway.context.SessionContext;

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ResetOperationTest.java
@@ -72,8 +72,8 @@ public class ResetOperationTest extends OperationTestBase {
 		ResultSet expected1 = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 			.columns(
-				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+				ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, 5)))
 			.data(properties)
 			.build();
 
@@ -98,8 +98,8 @@ public class ResetOperationTest extends OperationTestBase {
 		ResultSet expected2 = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 			.columns(
-				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+				ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, 5)))
 			.data(properties)
 			.build();
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SetOperationTest.java
@@ -62,8 +62,8 @@ public class SetOperationTest extends OperationTestBase {
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 			.columns(
-				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+				ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, 5)))
 			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),
@@ -85,8 +85,8 @@ public class SetOperationTest extends OperationTestBase {
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 			.columns(
-				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+				ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, 5)))
 			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),
@@ -105,8 +105,8 @@ public class SetOperationTest extends OperationTestBase {
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 			.columns(
-				ColumnInfo.create(ConstantNames.KEY, new VarCharType(true, 36)),
-				ColumnInfo.create(ConstantNames.VALUE, new VarCharType(true, 5)))
+				ColumnInfo.create(ConstantNames.SET_KEY, new VarCharType(true, 36)),
+				ColumnInfo.create(ConstantNames.SET_VALUE, new VarCharType(true, 5)))
 			.data(
 				Row.of("execution.max-parallelism", "16"),
 				Row.of("execution.planner", "old"),

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogsOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCatalogsOperationTest.java
@@ -36,9 +36,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link ShowViewOperation}.
+ * Tests for {@link ShowCatalogsOperation}.
  */
-public class ShowViewOperationTest extends OperationTestBase {
+public class ShowCatalogsOperationTest extends OperationTestBase {
 
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
 
@@ -52,19 +52,15 @@ public class ShowViewOperationTest extends OperationTestBase {
 	}
 
 	@Test
-	public void testShowView() {
-		ShowViewOperation operation = new ShowViewOperation(context);
+	public void testShowCatalog() {
+		ShowCatalogsOperation operation = new ShowCatalogsOperation(context);
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(
-				ColumnInfo.create(ConstantNames.VIEWS, new VarCharType(false, 9)))
-			.data(
-				Row.of("TestView1"),
-				Row.of("TestView2"))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_CATALOGS_RESULT, new VarCharType(false, 15)))
+			.data(Row.of("catalog1"), Row.of("default_catalog"), Row.of("simple-catalog"))
 			.build();
-
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentCatalogOperationTest.java
@@ -60,7 +60,7 @@ public class ShowCurrentCatalogOperationTest extends OperationTestBase {
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.CATALOG, new VarCharType(false, 14)))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_CURRENT_CATALOG_RESULT, new VarCharType(false, 14)))
 			.data(Row.of("simple-catalog"))
 			.build();
 		assertEquals(expected, resultSet);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowCurrentDatabaseOperationTest.java
@@ -61,7 +61,7 @@ public class ShowCurrentDatabaseOperationTest extends OperationTestBase {
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.DATABASE, new VarCharType(false, 7)))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_CURRENT_DATABASE_RESULT, new VarCharType(false, 7)))
 			.data(Row.of("default"))
 			.build();
 		assertEquals(expected, resultSet);

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabasesOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowDatabasesOperationTest.java
@@ -36,9 +36,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link ShowTableOperation}.
+ * Tests for {@link ShowDatabasesOperation}.
  */
-public class ShowTableOperationTest extends OperationTestBase {
+public class ShowDatabasesOperationTest extends OperationTestBase {
 
 	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
 
@@ -52,22 +52,17 @@ public class ShowTableOperationTest extends OperationTestBase {
 	}
 
 	@Test
-	public void testShowTable() {
-		ShowTableOperation operation = new ShowTableOperation(context);
+	public void testShowDatabase() {
+		context.getExecutionContext().getTableEnvironment().useCatalog("catalog1");
+
+		ShowDatabasesOperation operation = new ShowDatabasesOperation(context);
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(
-				ColumnInfo.create(ConstantNames.TABLES, new VarCharType(false, 15)))
-			.data(
-				Row.of("TableNumber1"),
-				Row.of("TableNumber2"),
-				Row.of("TableSourceSink"),
-				Row.of("TestView1"),
-				Row.of("TestView2"))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_DATABASES_RESULT, new VarCharType(false, 7)))
+			.data(Row.of("default"))
 			.build();
-
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowFunctionsOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowFunctionsOperationTest.java
@@ -16,20 +16,23 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.operation;
+
+import com.ververica.flink.table.gateway.rest.result.ResultSet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
- * Exception thrown during parsing SQL statement.
+ * Tests for {@link ShowFunctionsOperation}.
  */
-public class SqlParseException extends RuntimeException {
+public class ShowFunctionsOperationTest extends OperationTestBase {
 
-	private static final long serialVersionUID = 1L;
-
-	public SqlParseException(String message) {
-		super(message);
-	}
-
-	public SqlParseException(String message, Throwable e) {
-		super(message, e);
+	@Test
+	public void testShowFunction() {
+		ShowFunctionsOperation operation = new ShowFunctionsOperation(context);
+		ResultSet resultSet = operation.execute();
+		assertTrue(resultSet.getData().size() > 0);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowModulesOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowModulesOperationTest.java
@@ -36,32 +36,29 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link ShowDatabaseOperation}.
+ * Tests for {@link ShowModulesOperation}.
  */
-public class ShowDatabaseOperationTest extends OperationTestBase {
+public class ShowModulesOperationTest extends OperationTestBase {
 
-	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
+	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-modules.yaml";
 
 	@Override
 	protected Environment getSessionEnvironment() throws Exception {
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_PLANNER", "old");
 		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
-		replaceVars.put("$VAR_UPDATE_MODE", "");
 		return EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
 	}
 
 	@Test
-	public void testShowDatabase() {
-		context.getExecutionContext().getTableEnvironment().useCatalog("catalog1");
-
-		ShowDatabaseOperation operation = new ShowDatabaseOperation(context);
+	public void testShowModule() {
+		ShowModulesOperation operation = new ShowModulesOperation(context);
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.DATABASES, new VarCharType(false, 7)))
-			.data(Row.of("default"))
+			.columns(ColumnInfo.create(ConstantNames.SHOW_MODULES_RESULT, new VarCharType(false, 8)))
+			.data(Row.of("core"), Row.of("mymodule"), Row.of("myhive"), Row.of("myhive2"))
 			.build();
 		assertEquals(expected, resultSet);
 	}

--- a/src/test/java/com/ververica/flink/table/gateway/operation/ShowViewsOperationTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/ShowViewsOperationTest.java
@@ -36,30 +36,35 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link ShowModuleOperation}.
+ * Tests for {@link ShowViewsOperation}.
  */
-public class ShowModuleOperationTest extends OperationTestBase {
+public class ShowViewsOperationTest extends OperationTestBase {
 
-	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-modules.yaml";
+	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
 
 	@Override
 	protected Environment getSessionEnvironment() throws Exception {
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_PLANNER", "old");
 		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
+		replaceVars.put("$VAR_UPDATE_MODE", "");
 		return EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
 	}
 
 	@Test
-	public void testShowModule() {
-		ShowModuleOperation operation = new ShowModuleOperation(context);
+	public void testShowView() {
+		ShowViewsOperation operation = new ShowViewsOperation(context);
 		ResultSet resultSet = operation.execute();
 
 		ResultSet expected = ResultSet.builder()
 			.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-			.columns(ColumnInfo.create(ConstantNames.MODULES, new VarCharType(false, 8)))
-			.data(Row.of("core"), Row.of("mymodule"), Row.of("myhive"), Row.of("myhive2"))
+			.columns(
+				ColumnInfo.create(ConstantNames.SHOW_VIEWS_RESULT, new VarCharType(false, 9)))
+			.data(
+				Row.of("TestView1"),
+				Row.of("TestView2"))
 			.build();
+
 		assertEquals(expected, resultSet);
 	}
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
-package com.ververica.flink.table.gateway;
+package com.ververica.flink.table.gateway.operation;
 
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommand;
-import com.ververica.flink.table.gateway.SqlCommandParser.SqlCommandCall;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommand;
+import com.ververica.flink.table.gateway.operation.SqlCommandParser.SqlCommandCall;
 
 import org.junit.Test;
 


### PR DESCRIPTION
This PR cleans up code base a bit. Precisely speaking, this PR
- Rename some operations to their correct names.
- Fix bad indents of some method declarations.
- Clean up `ConstantNames` fields with more proper names.
- Move most classes in root package into proper sub-packages.