### PR TITLE
Set DML result column names to table identifier

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -66,12 +65,12 @@ public class InsertOperation extends AbstractJobOperation {
 
 	private boolean fetched = false;
 
-	public InsertOperation(SessionContext context, String statement) {
+	public InsertOperation(SessionContext context, String statement, String tableIdentifier) {
 		super(context);
 		this.statement = statement;
 
-		this.columnInfos = new ArrayList<>();
-		this.columnInfos.add(ColumnInfo.create(ConstantNames.AFFECTED_ROW_COUNT, new BigIntType(false)));
+		this.columnInfos = Collections.singletonList(
+			ColumnInfo.create(tableIdentifier, new BigIntType(false)));
 	}
 
 	@Override

--- a/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/OperationFactory.java
@@ -71,7 +71,7 @@ public class OperationFactory {
 				break;
 			case INSERT_INTO:
 			case INSERT_OVERWRITE:
-				operation = new InsertOperation(context, call.operands[0]);
+				operation = new InsertOperation(context, call.operands[0], call.operands[1]);
 				break;
 			case SHOW_MODULES:
 				operation = new ShowModulesOperation(context);

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
@@ -128,8 +128,9 @@ public final class SqlCommandParser {
 			cmd = SqlCommand.SELECT;
 			operands = new String[] { stmt };
 		} else if (node instanceof RichSqlInsert) {
-			cmd = ((RichSqlInsert) node).isOverwrite() ? SqlCommand.INSERT_OVERWRITE : SqlCommand.INSERT_INTO;
-			operands = new String[] { stmt };
+			RichSqlInsert insertNode = (RichSqlInsert) node;
+			cmd = insertNode.isOverwrite() ? SqlCommand.INSERT_OVERWRITE : SqlCommand.INSERT_INTO;
+			operands = new String[] { stmt, insertNode.getTargetTable().toString() };
 		} else if (node instanceof SqlShowTables) {
 			cmd = SqlCommand.SHOW_TABLES;
 			operands = new String[0];

--- a/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
+++ b/src/main/java/com/ververica/flink/table/gateway/rest/result/ConstantNames.java
@@ -26,9 +26,6 @@ public class ConstantNames {
 	// for statement execution
 	public static final String JOB_ID = "job_id";
 
-	// for DMLs
-	public static final String AFFECTED_ROW_COUNT = "affected_row_count";
-
 	// for results with SUCCESS result kind
 	public static final String RESULT = "result";
 	public static final String OK = "OK";

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
@@ -88,21 +88,21 @@ public class SqlCommandParserTest {
 	@Test
 	public void testInsert() {
 		String query1 = "insert into MySink select * from MyTable where a > 10";
-		checkCommand(query1, SqlCommand.INSERT_INTO, query1);
+		checkCommand(query1, SqlCommand.INSERT_INTO, query1, "MySink");
 
 		String query2 = "\n -- single-line comment \n insert into MySink select * from MyTable where a > 10 " +
 			"/* multi-line comments \n more comments */ \n";
-		checkCommand(query2, SqlCommand.INSERT_INTO, query2);
+		checkCommand(query2, SqlCommand.INSERT_INTO, query2, "MySink");
 	}
 
 	@Test
 	public void testInsertOverwrite() {
 		String query1 = "insert overwrite MySink select * from MyTable where a > 10";
-		checkCommand(query1, SqlCommand.INSERT_OVERWRITE, query1);
+		checkCommand(query1, SqlCommand.INSERT_OVERWRITE, query1, "MySink");
 
 		String query2 = "\n -- single-line comment \n insert overwrite MySink select * from MyTable where a > 10 " +
 			"/* multi-line comments \n more comments */ \n";
-		checkCommand(query2, SqlCommand.INSERT_OVERWRITE, query2);
+		checkCommand(query2, SqlCommand.INSERT_OVERWRITE, query2, "MySink");
 	}
 
 	@Test

--- a/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/SqlCommandParserTest.java
@@ -93,6 +93,10 @@ public class SqlCommandParserTest {
 		String query2 = "\n -- single-line comment \n insert into MySink select * from MyTable where a > 10 " +
 			"/* multi-line comments \n more comments */ \n";
 		checkCommand(query2, SqlCommand.INSERT_INTO, query2, "MySink");
+
+		String query3 = "\n -- single-line comment \n insert into MyCat.MyDb.MySink " +
+			"select * from MyTable where a > 10 /* multi-line comments \n more comments */ \n";
+		checkCommand(query3, SqlCommand.INSERT_INTO, query3, "MyCat.MyDb.MySink");
 	}
 
 	@Test


### PR DESCRIPTION
[FLINK-16367](https://github.com/apache/flink/pull/12042) sets the column name of a `ModifyOperation` to the sink identifier.

This PR changes the column name in the job results of a INSERT statement from `affected_row_count` to the table identifier.

This change is also useful in the future when we want to support multiple statements execution. With this change, users can tell which result set belongs to which INSERT statement if they submit multiple INSERT statements at a time.