### PR TITLE
Fix a bug about Environment merge

### DIFF
--- a/src/main/java/com/ververica/flink/table/gateway/config/entries/ServerEntry.java
+++ b/src/main/java/com/ververica/flink/table/gateway/config/entries/ServerEntry.java
@@ -72,8 +72,8 @@ public class ServerEntry extends ConfigEntry {
 	 * overwritten by the second one.
 	 */
 	public static ServerEntry merge(ServerEntry gateway1, ServerEntry gateway2) {
-		final Map<String, String> mergedProperties = new HashMap<>(gateway1.asTopLevelMap());
-		mergedProperties.putAll(gateway2.asTopLevelMap());
+		final Map<String, String> mergedProperties = new HashMap<>(gateway1.asMap());
+		mergedProperties.putAll(gateway2.asMap());
 
 		final DescriptorProperties properties = new DescriptorProperties(true);
 		properties.putProperties(mergedProperties);

--- a/src/main/java/com/ververica/flink/table/gateway/config/entries/SessionEntry.java
+++ b/src/main/java/com/ververica/flink/table/gateway/config/entries/SessionEntry.java
@@ -65,8 +65,8 @@ public class SessionEntry extends ConfigEntry {
 	 * overwritten by the second one.
 	 */
 	public static SessionEntry merge(SessionEntry session1, SessionEntry session2) {
-		final Map<String, String> mergedProperties = new HashMap<>(session1.asTopLevelMap());
-		mergedProperties.putAll(session2.asTopLevelMap());
+		final Map<String, String> mergedProperties = new HashMap<>(session1.asMap());
+		mergedProperties.putAll(session2.asMap());
 
 		final DescriptorProperties properties = new DescriptorProperties(true);
 		properties.putProperties(mergedProperties);


### PR DESCRIPTION
This PR fix a bug about Environment merge, specifically SessionEntry and ServerEntry.
When merging two SessionEntry or ServerEntry, asTopLevelMap is called to add prefix to merged properties. This leads us to get the default value defined in OrElse, instead of correct value when we call get functions of entry.