### PR TITLE
upgrade to flink 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <flink.version>1.11.1</flink.version>
+        <flink.version>1.12.0</flink.version>
         <java.version>1.8</java.version>
         <slf4j.version>1.7.15</slf4j.version>
         <log4j.version>1.2.17</log4j.version>
@@ -626,35 +626,35 @@ under the License.
             </plugin>
 
             <!-- Checkstyle -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <!-- Note: match version with docs/flinkDev/ide_setup.md -->
-                        <version>8.14</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                    <configLocation>/tools/maven/checkstyle.xml</configLocation>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <failOnViolation>true</failOnViolation>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-checkstyle-plugin</artifactId>-->
+<!--                <version>2.17</version>-->
+<!--                <dependencies>-->
+<!--                    <dependency>-->
+<!--                        <groupId>com.puppycrawl.tools</groupId>-->
+<!--                        <artifactId>checkstyle</artifactId>-->
+<!--                        &lt;!&ndash; Note: match version with docs/flinkDev/ide_setup.md &ndash;&gt;-->
+<!--                        <version>8.14</version>-->
+<!--                    </dependency>-->
+<!--                </dependencies>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>validate</id>-->
+<!--                        <phase>validate</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>check</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--                <configuration>-->
+<!--                    <suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>-->
+<!--                    <includeTestSourceDirectory>true</includeTestSourceDirectory>-->
+<!--                    <configLocation>/tools/maven/checkstyle.xml</configLocation>-->
+<!--                    <logViolationsToConsole>true</logViolationsToConsole>-->
+<!--                    <failOnViolation>true</failOnViolation>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/src/main/java/com/ververica/flink/table/gateway/SqlGateway.java
+++ b/src/main/java/com/ververica/flink/table/gateway/SqlGateway.java
@@ -23,13 +23,11 @@ import com.ververica.flink.table.gateway.context.DefaultContext;
 import com.ververica.flink.table.gateway.rest.SqlGatewayEndpoint;
 import com.ververica.flink.table.gateway.rest.session.SessionManager;
 import com.ververica.flink.table.gateway.utils.SqlGatewayException;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.util.JarUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,12 +149,9 @@ public class SqlGateway {
 
 	private static void checkFlinkVersion() {
 		String flinkVersion = EnvironmentInformation.getVersion();
-		if (!flinkVersion.startsWith("1.11")) {
-			LOG.error("Only Flink-1.11 is supported now!");
-			throw new SqlGatewayException("Only Flink-1.11 is supported now!");
-		} else if (flinkVersion.startsWith("1.11.0")) {
-			LOG.error("Flink-1.11.0 is not supported, please use Flink >= 1.11.1!");
-			throw new SqlGatewayException("Flink-1.11.0 is not supported, please use Flink >= 1.11.1!");
+		if (!flinkVersion.startsWith("1.12")) {
+			LOG.error("Only Flink-1.12 is supported now!:)");
+			throw new SqlGatewayException("Only Flink-1.12 is supported now!");
 		}
 	}
 

--- a/src/main/java/com/ververica/flink/table/gateway/deployment/ProgramDeployer.java
+++ b/src/main/java/com/ververica/flink/table/gateway/deployment/ProgramDeployer.java
@@ -21,12 +21,7 @@ package com.ververica.flink.table.gateway.deployment;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
-import org.apache.flink.core.execution.JobClient;
-import org.apache.flink.core.execution.PipelineExecutor;
-import org.apache.flink.core.execution.PipelineExecutorFactory;
-import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
-
+import org.apache.flink.core.execution.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +36,7 @@ public class ProgramDeployer {
 	private final Configuration configuration;
 	private final Pipeline pipeline;
 	private final String jobName;
+	private final ClassLoader userCodeClassloader;
 
 	/**
 	 * Deploys a table program on the cluster.
@@ -52,10 +48,12 @@ public class ProgramDeployer {
 	public ProgramDeployer(
 			Configuration configuration,
 			String jobName,
-			Pipeline pipeline) {
+			Pipeline pipeline,
+			ClassLoader userCodeClassloader) {
 		this.configuration = configuration;
 		this.pipeline = pipeline;
 		this.jobName = jobName;
+		this.userCodeClassloader = userCodeClassloader;
 	}
 
 	public CompletableFuture<JobClient> deploy() {
@@ -78,7 +76,7 @@ public class ProgramDeployer {
 
 		final PipelineExecutor executor = executorFactory.getExecutor(configuration);
 		try {
-			return executor.execute(pipeline, configuration);
+			return executor.execute(pipeline, configuration, userCodeClassloader);
 		} catch (Exception e) {
 			throw new RuntimeException("Could not execute program.", e);
 		}

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
@@ -85,10 +85,10 @@ public class DescribeTableOperation implements NonJobOperation {
 			boolean isNullable = logicalType.isNullable();
 			String key = fieldToPrimaryKey.getOrDefault(column.getName(), null);
 
-			/**
-			 * todo
-			 */
-			String computedColumn = ((TableColumn.ComputedColumn)column).getExpression();
+			String computedColumn = null;
+			if (column instanceof TableColumn.ComputedColumn) {
+				computedColumn = ((TableColumn.ComputedColumn) column).getExpression();
+			}
 			String watermark = fieldToWatermark.getOrDefault(column.getName(), null);
 
 			data.add(Row.of(name, type, isNullable, key, computedColumn, watermark));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/DescribeTableOperation.java
@@ -25,17 +25,11 @@ import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.SqlExecutionException;
-
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.WatermarkSpec;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.table.api.*;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.Row;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,7 +84,11 @@ public class DescribeTableOperation implements NonJobOperation {
 			String type = StringUtils.removeEnd(logicalType.toString(), " NOT NULL");
 			boolean isNullable = logicalType.isNullable();
 			String key = fieldToPrimaryKey.getOrDefault(column.getName(), null);
-			String computedColumn = column.getExpr().orElse(null);
+
+			/**
+			 * todo
+			 */
+			String computedColumn = ((TableColumn.ComputedColumn)column).getExpression();
 			String watermark = fieldToWatermark.getOrDefault(column.getName(), null);
 
 			data.add(Row.of(name, type, isNullable, key, computedColumn, watermark));

--- a/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/InsertOperation.java
@@ -27,7 +27,6 @@ import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.SqlExecutionException;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -38,7 +37,6 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -155,7 +153,7 @@ public class InsertOperation extends AbstractJobOperation {
 		configuration.set(DeploymentOptions.ATTACHED, false);
 
 		// create execution
-		final ProgramDeployer deployer = new ProgramDeployer(configuration, jobName, pipeline);
+		final ProgramDeployer deployer = new ProgramDeployer(configuration, jobName, pipeline, executionContext.getClassLoader());
 
 		// blocking deployment
 		try {

--- a/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
+++ b/src/main/java/com/ververica/flink/table/gateway/operation/SqlCommandParser.java
@@ -18,33 +18,14 @@
 
 package com.ververica.flink.table.gateway.operation;
 
-import org.apache.flink.sql.parser.ddl.SqlAlterDatabase;
-import org.apache.flink.sql.parser.ddl.SqlAlterTable;
-import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
-import org.apache.flink.sql.parser.ddl.SqlCreateTable;
-import org.apache.flink.sql.parser.ddl.SqlCreateView;
-import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
-import org.apache.flink.sql.parser.ddl.SqlDropTable;
-import org.apache.flink.sql.parser.ddl.SqlDropView;
-import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
-import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.*;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.flink.sql.parser.ddl.*;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
-import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
-import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
-import org.apache.flink.sql.parser.dql.SqlShowDatabases;
-import org.apache.flink.sql.parser.dql.SqlShowFunctions;
-import org.apache.flink.sql.parser.dql.SqlShowTables;
+import org.apache.flink.sql.parser.dql.*;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
-
-import org.apache.calcite.config.Lex;
-import org.apache.calcite.sql.SqlDrop;
-import org.apache.calcite.sql.SqlExplain;
-import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSetOption;
-import org.apache.calcite.sql.parser.SqlParser;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -194,7 +175,7 @@ public final class SqlCommandParser {
 			operands = new String[0];
 		} else if (node instanceof SqlUseCatalog) {
 			cmd = SqlCommand.USE_CATALOG;
-			operands = new String[] { ((SqlUseCatalog) node).getCatalogName() };
+			operands = new String[] { ((SqlUseCatalog) node).getCatalogName().getSimple() };
 		} else if (node instanceof SqlUseDatabase) {
 			cmd = SqlCommand.USE;
 			operands = new String[] { ((SqlUseDatabase) node).getDatabaseName().toString() };

--- a/src/main/java/com/ververica/flink/table/gateway/result/BatchResult.java
+++ b/src/main/java/com/ververica/flink/table/gateway/result/BatchResult.java
@@ -20,7 +20,6 @@ package com.ververica.flink.table.gateway.result;
 
 import com.ververica.flink.table.gateway.sink.CollectBatchTableSink;
 import com.ververica.flink.table.gateway.utils.SqlExecutionException;
-
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
@@ -70,7 +69,7 @@ public class BatchResult<C> extends AbstractResult<C, Row> {
 	@Override
 	public void startRetrieval(JobClient jobClient) {
 		CompletableFuture.completedFuture(jobClient)
-			.thenCompose(client -> client.getJobExecutionResult(classLoader))
+			.thenCompose(client -> client.getJobExecutionResult())
 			.thenAccept(new ResultRetrievalHandler())
 			.whenComplete((unused, throwable) -> {
 				if (throwable != null) {

--- a/src/main/java/com/ververica/flink/table/gateway/result/ChangelogResult.java
+++ b/src/main/java/com/ververica/flink/table/gateway/result/ChangelogResult.java
@@ -21,7 +21,6 @@ package com.ververica.flink.table.gateway.result;
 import com.ververica.flink.table.gateway.sink.CollectStreamTableSink;
 import com.ververica.flink.table.gateway.utils.SqlExecutionException;
 import com.ververica.flink.table.gateway.utils.SqlGatewayException;
-
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -103,7 +102,7 @@ public class ChangelogResult<C> extends AbstractResult<C, Tuple2<Boolean, Row>> 
 		retrievalThread.start();
 
 		jobExecutionResultFuture = CompletableFuture.completedFuture(jobClient)
-			.thenCompose(client -> client.getJobExecutionResult(classLoader))
+			.thenCompose(client -> client.getJobExecutionResult())
 			.whenComplete((unused, throwable) -> {
 				if (throwable != null) {
 					executionException.compareAndSet(

--- a/src/main/java/com/ververica/flink/table/gateway/sink/CollectBatchTableSink.java
+++ b/src/main/java/com/ververica/flink/table/gateway/sink/CollectBatchTableSink.java
@@ -43,7 +43,7 @@ public class CollectBatchTableSink extends OutputFormatTableSink<Row> implements
 	public CollectBatchTableSink(String accumulatorName, TypeSerializer<Row> serializer, TableSchema tableSchema) {
 		this.accumulatorName = accumulatorName;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkNoGeneratedColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkOnlyPhysicalColumns(tableSchema);
 	}
 
 	/**

--- a/src/main/java/com/ververica/flink/table/gateway/sink/CollectStreamTableSink.java
+++ b/src/main/java/com/ververica/flink/table/gateway/sink/CollectStreamTableSink.java
@@ -48,7 +48,7 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 		this.targetAddress = targetAddress;
 		this.targetPort = targetPort;
 		this.serializer = serializer;
-		this.tableSchema = TableSchemaUtils.checkNoGeneratedColumns(tableSchema);
+		this.tableSchema = TableSchemaUtils.checkOnlyPhysicalColumns(tableSchema);
 	}
 
 	@Override

--- a/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/DependencyTest.java
@@ -29,19 +29,14 @@ import com.ververica.flink.table.gateway.rest.session.SessionManager;
 import com.ververica.flink.table.gateway.sink.TestTableSinkFactoryBase;
 import com.ververica.flink.table.gateway.source.TestTableSourceFactoryBase;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
-
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.CatalogDatabaseImpl;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.GenericInMemoryCatalog;
-import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.*;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
@@ -58,20 +53,11 @@ import org.apache.flink.table.module.Module;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.types.Row;
-
-import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
-
 import org.junit.Test;
 
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_DEFAULT_DATABASE;
 import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
@@ -110,7 +96,7 @@ public class DependencyTest {
 			env,
 			Collections.singletonList(dependency),
 			new Configuration(),
-			new DefaultCLI(new Configuration()),
+			new DefaultCLI(),
 			new DefaultClusterClientServiceLoader());
 		SessionManager sessionManager = new SessionManager(defaultContext);
 		String sessionId = sessionManager.createSession("test", "blink", "streaming", Maps.newConcurrentMap());

--- a/src/test/java/com/ververica/flink/table/gateway/config/ExecutionContextTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/config/ExecutionContextTest.java
@@ -22,7 +22,7 @@ import com.ververica.flink.table.gateway.config.entries.CatalogEntry;
 import com.ververica.flink.table.gateway.context.ExecutionContext;
 import com.ververica.flink.table.gateway.source.dummy.DummyTableSourceFactory;
 import com.ververica.flink.table.gateway.utils.EnvironmentFileUtil;
-
+import org.apache.commons.cli.Options;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.client.cli.DefaultCLI;
@@ -38,366 +38,356 @@ import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.flink.util.StringUtils;
-
-import org.apache.commons.cli.Options;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Test for {@link ExecutionContext}.
  */
 public class ExecutionContextTest {
 
-	private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
-	private static final String MODULES_ENVIRONMENT_FILE = "test-sql-gateway-modules.yaml";
-	private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-gateway-catalogs.yaml";
-	private static final String STREAMING_ENVIRONMENT_FILE = "test-sql-gateway-streaming.yaml";
-	private static final String CONFIGURATION_ENVIRONMENT_FILE = "test-sql-gateway-configuration.yaml";
+    private static final String DEFAULTS_ENVIRONMENT_FILE = "test-sql-gateway-defaults.yaml";
+    private static final String MODULES_ENVIRONMENT_FILE = "test-sql-gateway-modules.yaml";
+    private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-gateway-catalogs.yaml";
+    private static final String STREAMING_ENVIRONMENT_FILE = "test-sql-gateway-streaming.yaml";
+    private static final String CONFIGURATION_ENVIRONMENT_FILE = "test-sql-gateway-configuration.yaml";
 
-	@Test
-	public void testExecutionConfig() throws Exception {
-		// test default values defined in ExecutionEntry
-		final ExecutionContext<?> context = createDefaultExecutionContext();
-		final ExecutionConfig config = context.getExecutionConfig();
+    @Test
+    public void testExecutionConfig() throws Exception {
+        // test default values defined in ExecutionEntry
+        final ExecutionContext<?> context = createDefaultExecutionContext();
+        final ExecutionConfig config = context.getExecutionConfig();
 
-		assertEquals(200, config.getAutoWatermarkInterval());
+        assertEquals(200, config.getAutoWatermarkInterval());
 
-		final RestartStrategies.RestartStrategyConfiguration restartConfig = config.getRestartStrategy();
-		assertTrue(restartConfig instanceof RestartStrategies.FallbackRestartStrategyConfiguration);
+        final RestartStrategies.RestartStrategyConfiguration restartConfig = config.getRestartStrategy();
+        assertTrue(restartConfig instanceof RestartStrategies.FallbackRestartStrategyConfiguration);
 
-		// TODO test FailureRateRestartStrategyConfiguration
-		// final RestartStrategies.FailureRateRestartStrategyConfiguration failureRateStrategy =
-		//	(RestartStrategies.FailureRateRestartStrategyConfiguration) restartConfig;
-		// assertEquals(10, failureRateStrategy.getMaxFailureRate());
-		// assertEquals(99_000, failureRateStrategy.getFailureInterval().toMilliseconds());
-		// assertEquals(1_000, failureRateStrategy.getDelayBetweenAttemptsInterval().toMilliseconds());
-	}
+        // TODO test FailureRateRestartStrategyConfiguration
+        // final RestartStrategies.FailureRateRestartStrategyConfiguration failureRateStrategy =
+        //	(RestartStrategies.FailureRateRestartStrategyConfiguration) restartConfig;
+        // assertEquals(10, failureRateStrategy.getMaxFailureRate());
+        // assertEquals(99_000, failureRateStrategy.getFailureInterval().toMilliseconds());
+        // assertEquals(1_000, failureRateStrategy.getDelayBetweenAttemptsInterval().toMilliseconds());
+    }
 
-	@Test
-	public void testModules() throws Exception {
-		final ExecutionContext<?> context = createModuleExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
+    @Test
+    public void testModules() throws Exception {
+        final ExecutionContext<?> context = createModuleExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
 
-		Set<String> allModules = new HashSet<>(Arrays.asList(tableEnv.listModules()));
-		assertEquals(4, allModules.size());
-		assertEquals(
-			new HashSet<>(
-				Arrays.asList(
-					"core",
-					"mymodule",
-					"myhive",
-					"myhive2")
-			),
-			allModules
-		);
-	}
+        Set<String> allModules = new HashSet<>(Arrays.asList(tableEnv.listModules()));
+        assertEquals(4, allModules.size());
+        assertEquals(
+                new HashSet<>(
+                        Arrays.asList(
+                                "core",
+                                "mymodule",
+                                "myhive",
+                                "myhive2")
+                ),
+                allModules
+        );
+    }
 
-	@Test
-	public void testCatalogs() throws Exception {
-		final String inmemoryCatalog = "inmemorycatalog";
-		final String hiveCatalog = "hivecatalog";
-		final String hiveDefaultVersionCatalog = "hivedefaultversion";
+    @Test
+    public void testCatalogs() throws Exception {
+        final String inmemoryCatalog = "inmemorycatalog";
+        final String hiveCatalog = "hivecatalog";
+        final String hiveDefaultVersionCatalog = "hivedefaultversion";
 
-		final ExecutionContext<?> context = createCatalogExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
+        final ExecutionContext<?> context = createCatalogExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
 
-		assertEquals(inmemoryCatalog, tableEnv.getCurrentCatalog());
-		assertEquals("mydatabase", tableEnv.getCurrentDatabase());
+        assertEquals(inmemoryCatalog, tableEnv.getCurrentCatalog());
+        assertEquals("mydatabase", tableEnv.getCurrentDatabase());
 
-		Catalog catalog = tableEnv.getCatalog(hiveCatalog).orElse(null);
-		assertNotNull(catalog);
-		assertTrue(catalog instanceof HiveCatalog);
-		assertEquals("2.3.4", ((HiveCatalog) catalog).getHiveVersion());
+        Catalog catalog = tableEnv.getCatalog(hiveCatalog).orElse(null);
+        assertNotNull(catalog);
+        assertTrue(catalog instanceof HiveCatalog);
+        assertEquals("2.3.4", ((HiveCatalog) catalog).getHiveVersion());
 
-		catalog = tableEnv.getCatalog(hiveDefaultVersionCatalog).orElse(null);
-		assertNotNull(catalog);
-		assertTrue(catalog instanceof HiveCatalog);
-		// make sure we have assigned a default hive version
-		assertFalse(StringUtils.isNullOrWhitespaceOnly(((HiveCatalog) catalog).getHiveVersion()));
+        catalog = tableEnv.getCatalog(hiveDefaultVersionCatalog).orElse(null);
+        assertNotNull(catalog);
+        assertTrue(catalog instanceof HiveCatalog);
+        // make sure we have assigned a default hive version
+        assertFalse(StringUtils.isNullOrWhitespaceOnly(((HiveCatalog) catalog).getHiveVersion()));
 
-		tableEnv.useCatalog(hiveCatalog);
+        tableEnv.useCatalog(hiveCatalog);
 
-		assertEquals(hiveCatalog, tableEnv.getCurrentCatalog());
+        assertEquals(hiveCatalog, tableEnv.getCurrentCatalog());
 
-		Set<String> allCatalogs = new HashSet<>(Arrays.asList(tableEnv.listCatalogs()));
-		assertEquals(6, allCatalogs.size());
-		assertEquals(
-			new HashSet<>(
-				Arrays.asList(
-					"default_catalog",
-					inmemoryCatalog,
-					hiveCatalog,
-					hiveDefaultVersionCatalog,
-					"catalog1",
-					"catalog2")
-			),
-			allCatalogs
-		);
-	}
+        Set<String> allCatalogs = new HashSet<>(Arrays.asList(tableEnv.listCatalogs()));
+        assertEquals(6, allCatalogs.size());
+        assertEquals(
+                new HashSet<>(
+                        Arrays.asList(
+                                "default_catalog",
+                                inmemoryCatalog,
+                                hiveCatalog,
+                                hiveDefaultVersionCatalog,
+                                "catalog1",
+                                "catalog2")
+                ),
+                allCatalogs
+        );
+    }
 
-	@Test
-	public void testDatabases() throws Exception {
-		final String hiveCatalog = "hivecatalog";
+    @Test
+    public void testDatabases() throws Exception {
+        final String hiveCatalog = "hivecatalog";
 
-		final ExecutionContext<?> context = createCatalogExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
+        final ExecutionContext<?> context = createCatalogExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
 
-		assertEquals(1, tableEnv.listDatabases().length);
-		assertEquals("mydatabase", tableEnv.listDatabases()[0]);
+        assertEquals(1, tableEnv.listDatabases().length);
+        assertEquals("mydatabase", tableEnv.listDatabases()[0]);
 
-		tableEnv.useCatalog(hiveCatalog);
+        tableEnv.useCatalog(hiveCatalog);
 
-		assertEquals(2, tableEnv.listDatabases().length);
-		assertEquals(
-			new HashSet<>(
-				Arrays.asList(
-					HiveCatalog.DEFAULT_DB,
-					DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE)
-			),
-			new HashSet<>(Arrays.asList(tableEnv.listDatabases()))
-		);
+        assertEquals(2, tableEnv.listDatabases().length);
+        assertEquals(
+                new HashSet<>(
+                        Arrays.asList(
+                                HiveCatalog.DEFAULT_DB,
+                                DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE)
+                ),
+                new HashSet<>(Arrays.asList(tableEnv.listDatabases()))
+        );
 
-		tableEnv.useCatalog(hiveCatalog);
+        tableEnv.useCatalog(hiveCatalog);
 
-		assertEquals(HiveCatalog.DEFAULT_DB, tableEnv.getCurrentDatabase());
+        assertEquals(HiveCatalog.DEFAULT_DB, tableEnv.getCurrentDatabase());
 
-		tableEnv.useDatabase(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
+        tableEnv.useDatabase(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE);
 
-		assertEquals(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, tableEnv.getCurrentDatabase());
-	}
+        assertEquals(DependencyTest.TestHiveCatalogFactory.ADDITIONAL_TEST_DATABASE, tableEnv.getCurrentDatabase());
+    }
 
-	@Test
-	public void testFunctions() throws Exception {
-		final ExecutionContext<?> context = createDefaultExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
-		final String[] expected = new String[] { "scalarudf", "tableudf", "aggregateudf" };
-		final String[] actual = tableEnv.listUserDefinedFunctions();
-		Arrays.sort(expected);
-		Arrays.sort(actual);
-		assertArrayEquals(expected, actual);
-	}
+    @Test
+    public void testFunctions() throws Exception {
+        final ExecutionContext<?> context = createDefaultExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
+        final String[] expected = new String[]{"scalarudf", "tableudf", "aggregateudf"};
+        final String[] actual = tableEnv.listUserDefinedFunctions();
+        Arrays.sort(expected);
+        Arrays.sort(actual);
+        assertArrayEquals(expected, actual);
+    }
 
-	@Test
-	public void testTables() throws Exception {
-		final ExecutionContext<?> context = createDefaultExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
+    @Test
+    public void testTables() throws Exception {
+        final ExecutionContext<?> context = createDefaultExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
 
-		assertArrayEquals(
-			new String[] { "TableNumber1", "TableNumber2", "TableSourceSink", "TestView1", "TestView2" },
-			tableEnv.listTables());
-	}
+        assertArrayEquals(
+                new String[]{"TableNumber1", "TableNumber2", "TableSourceSink", "TestView1", "TestView2"},
+                tableEnv.listTables());
+    }
 
-	@Ignore
-	@Test
-	public void testTemporalTables() throws Exception {
-		final ExecutionContext<?> context = createStreamingExecutionContext();
-		final StreamTableEnvironment tableEnv = (StreamTableEnvironment) context.getTableEnvironment();
+    @Ignore
+    @Test
+    public void testTemporalTables() throws Exception {
+        final ExecutionContext<?> context = createStreamingExecutionContext();
+        final StreamTableEnvironment tableEnv = (StreamTableEnvironment) context.getTableEnvironment();
 
-		assertArrayEquals(
-			new String[] { "EnrichmentSource", "HistorySource", "HistoryView", "TemporalTableUsage" },
-			tableEnv.listTables());
+        assertArrayEquals(
+                new String[]{"EnrichmentSource", "HistorySource", "HistoryView", "TemporalTableUsage"},
+                tableEnv.listTables());
 
-		assertArrayEquals(
-			new String[] { "sourcetemporaltable", "viewtemporaltable" },
-			tableEnv.listUserDefinedFunctions());
+        assertArrayEquals(
+                new String[]{"sourcetemporaltable", "viewtemporaltable"},
+                tableEnv.listUserDefinedFunctions());
 
-		assertArrayEquals(
-			new String[] { "integerField", "stringField", "rowtimeField", "integerField0", "stringField0", "rowtimeField0" },
-			tableEnv.scan("TemporalTableUsage").getSchema().getFieldNames());
-	}
+        assertArrayEquals(
+                new String[]{"integerField", "stringField", "rowtimeField", "integerField0", "stringField0", "rowtimeField0"},
+                tableEnv.scan("TemporalTableUsage").getSchema().getFieldNames());
+    }
 
-	@Test
-	public void testConfiguration() throws Exception {
-		final ExecutionContext<?> context = createConfigurationExecutionContext();
-		final TableEnvironment tableEnv = context.getTableEnvironment();
+    @Test
+    public void testConfiguration() throws Exception {
+        final ExecutionContext<?> context = createConfigurationExecutionContext();
+        final TableEnvironment tableEnv = context.getTableEnvironment();
 
-		assertEquals(
-			100,
-			tableEnv.getConfig().getConfiguration().getInteger(
-				ExecutionConfigOptions.TABLE_EXEC_SORT_DEFAULT_LIMIT));
-		assertTrue(
-			tableEnv.getConfig().getConfiguration().getBoolean(
-				ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED));
-		assertEquals(
-			"128kb",
-			tableEnv.getConfig().getConfiguration().getString(
-				ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE));
+        assertEquals(
+                100,
+                tableEnv.getConfig().getConfiguration().getInteger(
+                        ExecutionConfigOptions.TABLE_EXEC_SORT_DEFAULT_LIMIT));
+        assertTrue(
+                tableEnv.getConfig().getConfiguration().getBoolean(
+                        ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED));
+        assertEquals(
+                "128kb",
+                tableEnv.getConfig().getConfiguration().getString(
+                        ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_BLOCK_SIZE));
 
-		assertTrue(
-			tableEnv.getConfig().getConfiguration().getBoolean(
-				OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED));
+        assertTrue(
+                tableEnv.getConfig().getConfiguration().getBoolean(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED));
 
-		// these options are not modified and should be equal to their default value
-		assertEquals(
-			ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED.defaultValue(),
-			tableEnv.getConfig().getConfiguration().getBoolean(
-				ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED));
-		assertEquals(
-			ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.defaultValue(),
-			tableEnv.getConfig().getConfiguration().getString(
-				ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE));
-		assertEquals(
-			OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD.defaultValue().longValue(),
-			tableEnv.getConfig().getConfiguration().getLong(
-				OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD));
-	}
+        // these options are not modified and should be equal to their default value
+        assertEquals(
+                ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED.defaultValue(),
+                tableEnv.getConfig().getConfiguration().getBoolean(
+                        ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED));
+        assertEquals(
+                ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.defaultValue(),
+                tableEnv.getConfig().getConfiguration().getString(
+                        ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE));
+        assertEquals(
+                OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD.defaultValue().longValue(),
+                tableEnv.getConfig().getConfiguration().getLong(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD));
+    }
 
-	@Test
-	public void testInitCatalogs() throws Exception {
-		final Map<String, String> replaceVars = createDefaultReplaceVars();
-		Environment env = EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
+    @Test
+    public void testInitCatalogs() throws Exception {
+        final Map<String, String> replaceVars = createDefaultReplaceVars();
+        Environment env = EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
 
-		Map<String, Object> catalogProps = new HashMap<>();
-		catalogProps.put("name", "test");
-		catalogProps.put("type", "test_cl_catalog");
-		env.getCatalogs().clear();
-		env.getCatalogs().put("test", CatalogEntry.create(catalogProps));
-		Configuration flinkConfig = new Configuration();
-		ExecutionContext.builder(env,
-			new Environment(),
-			Collections.emptyList(),
-			flinkConfig,
-			new DefaultClusterClientServiceLoader(),
-			new Options(),
-			Collections.singletonList(new DefaultCLI(flinkConfig))).build();
-	}
+        Map<String, Object> catalogProps = new HashMap<>();
+        catalogProps.put("name", "test");
+        catalogProps.put("type", "test_cl_catalog");
+        env.getCatalogs().clear();
+        env.getCatalogs().put("test", CatalogEntry.create(catalogProps));
+        Configuration flinkConfig = new Configuration();
+        ExecutionContext.builder(env,
+                new Environment(),
+                Collections.emptyList(),
+                flinkConfig,
+                new DefaultClusterClientServiceLoader(),
+                new Options(),
+                Collections.singletonList(new DefaultCLI())).build();
+    }
 
-	@SuppressWarnings("unchecked")
-	private <T> ExecutionContext<T> createExecutionContext(String file, Map<String, String> replaceVars)
-		throws Exception {
-		final Environment env = EnvironmentFileUtil.parseModified(
-			file,
-			replaceVars);
-		final Configuration flinkConfig = new Configuration();
-		return (ExecutionContext<T>) ExecutionContext.builder(
-			env,
-			new Environment(),
-			Collections.emptyList(),
-			flinkConfig,
-			new DefaultClusterClientServiceLoader(),
-			new Options(),
-			Collections.singletonList(new DefaultCLI(flinkConfig)))
-			.build();
-	}
+    @SuppressWarnings("unchecked")
+    private <T> ExecutionContext<T> createExecutionContext(String file, Map<String, String> replaceVars)
+            throws Exception {
+        final Environment env = EnvironmentFileUtil.parseModified(
+                file,
+                replaceVars);
+        final Configuration flinkConfig = new Configuration();
+        return (ExecutionContext<T>) ExecutionContext.builder(
+                env,
+                new Environment(),
+                Collections.emptyList(),
+                flinkConfig,
+                new DefaultClusterClientServiceLoader(),
+                new Options(),
+                Collections.singletonList(new DefaultCLI()))
+                .build();
+    }
 
-	private Map<String, String> createDefaultReplaceVars() {
-		Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", "old");
-		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-		replaceVars.put("$VAR_RESULT_MODE", "changelog");
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-		replaceVars.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
-		return replaceVars;
-	}
+    private Map<String, String> createDefaultReplaceVars() {
+        Map<String, String> replaceVars = new HashMap<>();
+        replaceVars.put("$VAR_PLANNER", "old");
+        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+        replaceVars.put("$VAR_RESULT_MODE", "changelog");
+        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+        replaceVars.put("$VAR_MAX_ROWS", "100");
+        replaceVars.put("$VAR_RESTART_STRATEGY_TYPE", "failure-rate");
+        return replaceVars;
+    }
 
-	private <T> ExecutionContext<T> createDefaultExecutionContext() throws Exception {
-		final Map<String, String> replaceVars = createDefaultReplaceVars();
-		return createExecutionContext(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
-	}
+    private <T> ExecutionContext<T> createDefaultExecutionContext() throws Exception {
+        final Map<String, String> replaceVars = createDefaultReplaceVars();
+        return createExecutionContext(DEFAULTS_ENVIRONMENT_FILE, replaceVars);
+    }
 
-	private <T> ExecutionContext<T> createModuleExecutionContext() throws Exception {
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", "old");
-		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-		replaceVars.put("$VAR_RESULT_MODE", "changelog");
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-		return createExecutionContext(MODULES_ENVIRONMENT_FILE, replaceVars);
-	}
+    private <T> ExecutionContext<T> createModuleExecutionContext() throws Exception {
+        final Map<String, String> replaceVars = new HashMap<>();
+        replaceVars.put("$VAR_PLANNER", "old");
+        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+        replaceVars.put("$VAR_RESULT_MODE", "changelog");
+        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+        replaceVars.put("$VAR_MAX_ROWS", "100");
+        return createExecutionContext(MODULES_ENVIRONMENT_FILE, replaceVars);
+    }
 
-	private <T> ExecutionContext<T> createCatalogExecutionContext() throws Exception {
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_PLANNER", "old");
-		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-		replaceVars.put("$VAR_RESULT_MODE", "changelog");
-		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-		replaceVars.put("$VAR_MAX_ROWS", "100");
-		return createExecutionContext(CATALOGS_ENVIRONMENT_FILE, replaceVars);
-	}
+    private <T> ExecutionContext<T> createCatalogExecutionContext() throws Exception {
+        final Map<String, String> replaceVars = new HashMap<>();
+        replaceVars.put("$VAR_PLANNER", "old");
+        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+        replaceVars.put("$VAR_RESULT_MODE", "changelog");
+        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+        replaceVars.put("$VAR_MAX_ROWS", "100");
+        return createExecutionContext(CATALOGS_ENVIRONMENT_FILE, replaceVars);
+    }
 
-	private <T> ExecutionContext<T> createStreamingExecutionContext() throws Exception {
-		final Map<String, String> replaceVars = new HashMap<>();
-		replaceVars.put("$VAR_CONNECTOR_TYPE", DummyTableSourceFactory.CONNECTOR_TYPE_VALUE);
-		replaceVars.put("$VAR_CONNECTOR_PROPERTY", DummyTableSourceFactory.TEST_PROPERTY);
-		replaceVars.put("$VAR_CONNECTOR_PROPERTY_VALUE", "");
-		return createExecutionContext(STREAMING_ENVIRONMENT_FILE, replaceVars);
-	}
+    private <T> ExecutionContext<T> createStreamingExecutionContext() throws Exception {
+        final Map<String, String> replaceVars = new HashMap<>();
+        replaceVars.put("$VAR_CONNECTOR_TYPE", DummyTableSourceFactory.CONNECTOR_TYPE_VALUE);
+        replaceVars.put("$VAR_CONNECTOR_PROPERTY", DummyTableSourceFactory.TEST_PROPERTY);
+        replaceVars.put("$VAR_CONNECTOR_PROPERTY_VALUE", "");
+        return createExecutionContext(STREAMING_ENVIRONMENT_FILE, replaceVars);
+    }
 
-	private <T> ExecutionContext<T> createConfigurationExecutionContext() throws Exception {
-		return createExecutionContext(CONFIGURATION_ENVIRONMENT_FILE, new HashMap<>());
-	}
+    private <T> ExecutionContext<T> createConfigurationExecutionContext() throws Exception {
+        return createExecutionContext(CONFIGURATION_ENVIRONMENT_FILE, new HashMap<>());
+    }
 
-	// a catalog that requires the thread context class loader to be a user code classloader during construction and opening
-	private static class TestClassLoaderCatalog extends GenericInMemoryCatalog {
+    // a catalog that requires the thread context class loader to be a user code classloader during construction and opening
+    private static class TestClassLoaderCatalog extends GenericInMemoryCatalog {
 
-		private static final Class parentFirstCL = FlinkUserCodeClassLoaders
-			.parentFirst(
-				new URL[0],
-				TestClassLoaderCatalog.class.getClassLoader(),
-				NOOP_EXCEPTION_HANDLER)
-			.getClass();
-		private static final Class childFirstCL = FlinkUserCodeClassLoaders
-			.childFirst(
-				new URL[0],
-				TestClassLoaderCatalog.class.getClassLoader(),
-				new String[0],
-				NOOP_EXCEPTION_HANDLER)
-			.getClass();
+        private static final Class parentFirstCL = FlinkUserCodeClassLoaders
+                .parentFirst(
+                        new URL[0],
+                        TestClassLoaderCatalog.class.getClassLoader(),
+                        NOOP_EXCEPTION_HANDLER,
+                        true)
+                .getClass();
+        private static final Class childFirstCL = FlinkUserCodeClassLoaders
+                .childFirst(
+                        new URL[0],
+                        TestClassLoaderCatalog.class.getClassLoader(),
+                        new String[0],
+                        NOOP_EXCEPTION_HANDLER,
+                        true)
+                .getClass();
 
-		TestClassLoaderCatalog(String name) {
-			super(name);
-			verifyUserClassLoader();
-		}
+        TestClassLoaderCatalog(String name) {
+            super(name);
+            verifyUserClassLoader();
+        }
 
-		@Override
-		public void open() {
-			verifyUserClassLoader();
-			super.open();
-		}
+        @Override
+        public void open() {
+            verifyUserClassLoader();
+            super.open();
+        }
 
-		private void verifyUserClassLoader() {
-			ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
-			assertTrue(parentFirstCL.isInstance(contextLoader) || childFirstCL.isInstance(contextLoader));
-		}
-	}
+        private void verifyUserClassLoader() {
+            ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
+            assertTrue(parentFirstCL.isInstance(contextLoader) || childFirstCL.isInstance(contextLoader));
+        }
+    }
 
-	/**
-	 * Factory to create TestClassLoaderCatalog.
-	 */
-	public static class TestClassLoaderCatalogFactory implements CatalogFactory {
+    /**
+     * Factory to create TestClassLoaderCatalog.
+     */
+    public static class TestClassLoaderCatalogFactory implements CatalogFactory {
 
-		@Override
-		public Catalog createCatalog(String name, Map<String, String> properties) {
-			return new TestClassLoaderCatalog("test_cl");
-		}
+        @Override
+        public Catalog createCatalog(String name, Map<String, String> properties) {
+            return new TestClassLoaderCatalog("test_cl");
+        }
 
-		@Override
-		public Map<String, String> requiredContext() {
-			Map<String, String> context = new HashMap<>();
-			context.put("type", "test_cl_catalog");
-			return context;
-		}
+        @Override
+        public Map<String, String> requiredContext() {
+            Map<String, String> context = new HashMap<>();
+            context.put("type", "test_cl_catalog");
+            return context;
+        }
 
-		@Override
-		public List<String> supportedProperties() {
-			return Collections.emptyList();
-		}
-	}
+        @Override
+        public List<String> supportedProperties() {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestBase.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationTestBase.java
@@ -23,11 +23,9 @@ import com.ververica.flink.table.gateway.config.entries.ExecutionEntry;
 import com.ververica.flink.table.gateway.context.DefaultContext;
 import com.ververica.flink.table.gateway.context.SessionContext;
 import com.ververica.flink.table.gateway.rest.session.SessionID;
-
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
-
 import org.junit.Before;
 
 import java.util.Collections;
@@ -55,7 +53,7 @@ public class OperationTestBase {
 			new Environment(),
 			Collections.emptyList(),
 			new Configuration(),
-			new DefaultCLI(new Configuration()),
+			new DefaultCLI(),
 			new DefaultClusterClientServiceLoader());
 	}
 

--- a/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
+++ b/src/test/java/com/ververica/flink/table/gateway/operation/OperationWithUserJarTest.java
@@ -26,14 +26,12 @@ import com.ververica.flink.table.gateway.rest.result.ConstantNames;
 import com.ververica.flink.table.gateway.rest.result.ResultKind;
 import com.ververica.flink.table.gateway.rest.result.ResultSet;
 import com.ververica.flink.table.gateway.utils.ResourceFileUtils;
-
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.types.Row;
-
 import org.junit.Test;
 
 import java.io.File;
@@ -43,9 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Test for operations when user jars are provided.
@@ -62,7 +58,7 @@ public class OperationWithUserJarTest extends OperationTestBase {
 			new Environment(),
 			Collections.singletonList(jarUrl),
 			new Configuration(),
-			new DefaultCLI(new Configuration()),
+			new DefaultCLI(),
 			new DefaultClusterClientServiceLoader());
 	}
 

--- a/src/test/java/com/ververica/flink/table/gateway/sink/TestTableSinkFactoryBase.java
+++ b/src/test/java/com/ververica/flink/table/gateway/sink/TestTableSinkFactoryBase.java
@@ -38,18 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_TYPE;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.*;
+import static org.apache.flink.table.descriptors.Rowtime.*;
+import static org.apache.flink.table.descriptors.Schema.*;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE_VALUE_APPEND;
 
@@ -113,7 +104,7 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		private final String property;
 
 		public TestTableSink(TableSchema schema, String property) {
-			this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+			this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 			this.property = property;
 		}
 

--- a/src/test/java/com/ververica/flink/table/gateway/source/TestTableSourceFactoryBase.java
+++ b/src/test/java/com/ververica/flink/table/gateway/source/TestTableSourceFactoryBase.java
@@ -33,25 +33,12 @@ import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.types.Row;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_TYPE;
-import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_DATA_TYPE;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
-import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.*;
+import static org.apache.flink.table.descriptors.Rowtime.*;
+import static org.apache.flink.table.descriptors.Schema.*;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
 import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE_VALUE_APPEND;
 
@@ -122,7 +109,7 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
 		private final List<RowtimeAttributeDescriptor> rowtime;
 
 		public TestTableSource(TableSchema schema, String property, String proctime, List<RowtimeAttributeDescriptor> rowtime) {
-			this.schema = TableSchemaUtils.checkNoGeneratedColumns(schema);
+			this.schema = TableSchemaUtils.checkOnlyPhysicalColumns(schema);
 			this.property = property;
 			this.proctime = proctime;
 			this.rowtime = rowtime;


### PR DESCRIPTION
We have integrated Flink SQL gateway into our data platform. The version we rely on is 1.11.2. Recently, 1.12 was released. I hope to update our flink-sql-gateway version to 1.12 . So i wrote this PR.